### PR TITLE
enabled config-updater plugin, raw configs in separate folder

### DIFF
--- a/prow/cluster/02-plugin-config.yaml
+++ b/prow/cluster/02-plugin-config.yaml
@@ -22,3 +22,25 @@ data:
         - verify-owners
         - wip
         - yuks
+      nephio-project/test-infra:
+        plugins:
+        - approve
+        - assign
+        - blunderbuss
+        - config-updater
+        - help
+        - hold
+        - label
+        - lgtm
+        - trigger
+        - verify-owners
+        - wip
+        - yuks
+    config_updater:
+      maps:
+        prow/config/config.yaml:
+          name: config
+          namespace: prow
+        prow/config/plugins.yaml:
+          name: plugins
+          namespace: prow

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1,0 +1,84 @@
+prowjob_namespace: prow
+pod_namespace: test-pods
+
+in_repo_config:
+  enabled:
+    nephio-project/nephio-test-prow-project: true
+    nephio-project/nf-deploy-controller: true
+  allowed_clusters:
+    "*": ["default"]
+
+deck:
+ spyglass:
+   lenses:
+   - lens:
+       name: metadata
+     required_files:
+     - started.json|finished.json
+   - lens:
+       config:
+       name: buildlog
+     required_files:
+     - build-log.txt
+   - lens:
+       name: junit
+     required_files:
+     - .*/junit.*\.xml
+   - lens:
+       name: podinfo
+     required_files:
+     - podinfo.json
+
+plank:
+  job_url_prefix_config:
+    "*": http://prow.nephio.io/view/
+  report_templates:
+    '*': >-
+        [Full PR test history](http://prow.nephio.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
+        [Your PR dashboard](http://prow.nephio.io/pr?query=is:pr+state:open+author:{{with
+        index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
+  default_decoration_configs:
+    "*":
+      gcs_configuration:
+        bucket: gs://prow-nephio-sig-release
+        path_strategy: explicit
+      gcs_credentials_secret: gcs-credentials
+      utility_images:
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20221208-8898931a7f
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20221208-8898931a7f
+        initupload: gcr.io/k8s-prow/initupload:v20221208-8898931a7f
+        sidecar: gcr.io/k8s-prow/sidecar:v20221208-8898931a7f
+
+tide:
+  queries:
+  - labels:
+    - lgtm
+    - approved
+    missingLabels:
+    - needs-rebase
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+    - do-not-merge/invalid-owners-file
+    orgs:
+    - nephio-project
+
+decorate_all_jobs: true
+postsubmits:
+  nephio-project/nephio-test-prow-project:
+  - name: test-postsubmit
+    decorate: true
+    spec:
+      containers:
+        - image: alpine
+          command:
+            - /bin/printenv
+presubmits:
+  nephio-project/nephio-test-prow-project:
+  - name: test-presubmit
+    decorate: true
+    always_run: true
+    spec:
+      containers:
+        - image: alpine
+          command:
+            - /bin/printenv

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -1,0 +1,40 @@
+plugins:
+  nephio-project:
+    plugins:
+    - approve
+    - assign
+    - blunderbuss
+    - cat
+    - dog
+    - help
+    - heart
+    - hold
+    - label
+    - lgtm
+    - trigger
+    - verify-owners
+    - wip
+    - yuks
+  nephio-project/test-infra:
+    plugins:
+    - approve
+    - assign
+    - blunderbuss
+    - config-updater
+    - help
+    - hold
+    - label
+    - lgtm
+    - trigger
+    - verify-owners
+    - wip
+    - yuks
+
+config_updater:
+  maps:
+    prow/config/config.yaml:
+      name: config
+      namespace: prow
+    prow/config/plugins.yaml:
+      name: plugins
+      namespace: prow


### PR DESCRIPTION
Enabled config-updater plugin, it directly applies prow config on the ConfigMap so they were put in different folder than yamls for cluster creation and initial configuration