### PR TITLE
Enable override plugin

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -14,6 +14,7 @@ plugins:
     - verify-owners
     - wip
     - retitle
+    - override
   nephio-project/test-infra:
     plugins:
     - config-updater
@@ -46,3 +47,7 @@ approve:
     - nephio-project/free5gc
     - nephio-project/edge-status-aggregator
     require_self_approval: true
+    
+override:
+  allow_top_level_owners: true
+


### PR DESCRIPTION
This allows repo admins to force green status on the failing test as an exemption