### PR TITLE
Adding gcsweb browser

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -19,6 +19,7 @@ in_repo_config:
 
 deck:
  spyglass:
+   gcs_browser_prefix: http://34.173.197.43/gcs/
    lenses:
    - lens:
        name: metadata


### PR DESCRIPTION
GCSWEB app allows to browse prow's bucket to download build artifacts