### PR TITLE
Change default lgtm label behaviour

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -47,6 +47,7 @@ approve:
     - nephio-project/free5gc
     - nephio-project/edge-status-aggregator
     require_self_approval: true
+    lgtm_acts_as_approve: false
     
 override:
   allow_top_level_owners: true


### PR DESCRIPTION
According to the [documentation](https://github.com/kubernetes/test-infra/blob/master/prow/plugins/plugin-config-documented.yaml), the lgtm_acts_as_approve is set to true by default, this value results in undesired approvals on code reviews.