### PR TITLE
Create install ansible role

### DIFF
--- a/e2e/provision/playbooks/cluster.yml
+++ b/e2e/provision/playbooks/cluster.yml
@@ -35,3 +35,4 @@
       become: true
       cni_plugins_dir: /tmp/cni
     - bootstrap
+    - install

--- a/e2e/provision/playbooks/roles/install/README.md
+++ b/e2e/provision/playbooks/roles/install/README.md
@@ -1,0 +1,3 @@
+# Install
+
+This ansible role installs Nephio services on a target cluster.

--- a/e2e/provision/playbooks/roles/install/molecule/default/converge.yml
+++ b/e2e/provision/playbooks/roles/install/molecule/default/converge.yml
@@ -1,0 +1,16 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Include install
+      ansible.builtin.include_role:
+        name: install

--- a/e2e/provision/playbooks/roles/install/molecule/default/molecule.yml
+++ b/e2e/provision/playbooks/roles/install/molecule/default/molecule.yml
@@ -1,0 +1,31 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+dependency:
+  name: galaxy
+  options:
+    role-file: ../../../galaxy-requirements.yml
+driver:
+  name: vagrant
+lint: |
+  set -e
+  PATH=${PATH}
+  yamllint -c ../../../.yaml-lint.yml .
+platforms:
+  - name: bionic
+    box: generic/ubuntu2004
+    provider_options:
+      gui: false
+provisioner:
+  name: ansible
+verifier:
+  name: testinfra
+  options:
+    sudo: true

--- a/e2e/provision/playbooks/roles/install/molecule/default/prepare.yml
+++ b/e2e/provision/playbooks/roles/install/molecule/default/prepare.yml
@@ -1,0 +1,62 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+- name: Boostrap servers
+  hosts: all
+  pre_tasks:
+    - name: Update Apt cache
+      ansible.builtin.raw: apt-get update --allow-releaseinfo-change
+      become: true
+      changed_when: false
+    - name: Install pip package
+      become: true
+      ansible.builtin.package:
+        name: python3-pip
+        state: present
+      when: ansible_distribution == 'Ubuntu'
+    - name: Install kubernetes python package
+      become: true
+      ansible.builtin.pip:
+        name: kubernetes==26.1.0
+  roles:
+    - andrewrothstein.kind
+    - andrewrothstein.kubectl
+    - role: andrewrothstein.docker_engine
+      become: true
+  tasks:
+    - name: Unarchive /tmp/kpt.tgz into /usr/local/bin/
+      become: true
+      become_user: root
+      ansible.builtin.unarchive:
+        remote_src: true
+        src: https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.32/kpt_linux_amd64-1.0.0-beta.32.tar.gz
+        dest: /usr/local/bin/
+        creates: /usr/local/bin/kpt
+    - name: Get k8s clusters
+      become: true
+      ansible.builtin.command: kind get clusters
+      register: kind_get_cluster
+      failed_when: (kind_get_cluster.rc not in [0, 1])
+      changed_when: false
+    - name: Create management cluster
+      become: true
+      ansible.builtin.command: kind create cluster --config=-
+      args:
+        stdin: |
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          nodes:
+            - role: control-plane
+              image: kindest/node:v1.27.1
+              extraMounts:
+                - hostPath: /var/run/docker.sock
+                  containerPath: /var/run/docker.sock
+      when: not 'kind' in kind_get_cluster.stdout
+      changed_when: true

--- a/e2e/provision/playbooks/roles/install/molecule/default/tests/test_default.py
+++ b/e2e/provision/playbooks/roles/install/molecule/default/tests/test_default.py
@@ -1,0 +1,45 @@
+#   Copyright (c) 2023 The Nephio Authors.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+
+
+def test_deployments(host):
+    expected = {
+        "config-management-monitoring": ["otel-collector"],
+        "config-management-system": [
+            "config-management-operator",
+            "reconciler-manager",
+        ],
+        "porch-system": [
+            "function-runner",
+            "porch-controllers",
+            "porch-server",
+        ],
+        "nephio-system": [
+            "ipam-controller",
+            "nephio-5gc-controller",
+            "nf-injector-controller",
+            "package-deployment-controller-controller",
+        ],
+        "nephio-webui": ["nephio-webui"],
+        "resource-group-system": ["resource-group-controller-manager"],
+    }
+    got = host.check_output(
+        'kubectl get deploy -A \
+-o jsonpath=\'{range .items[*]}{.metadata.name}{" "}{.metadata.namespace}\
+{"\\n"}{end}\''
+    )
+    for namespace, deployments in expected.items():
+        for deploy in deployments:
+            assert deploy + " " + namespace in got

--- a/e2e/provision/playbooks/roles/install/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/install/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+- name: Deploy Nephio packages
+  ansible.builtin.include_role:
+    name: kpt
+  loop:
+    - {pkg: nephio-system, version: nephio-system/v6}
+    - {pkg: nephio-webui, version: nephio-webui/v6}
+  vars:
+    repo_uri: https://github.com/nephio-project/nephio-packages
+    local_dest_directory: /tmp
+    pkg: "{{ item.pkg }}"
+    version: "{{ item.version }}"

--- a/e2e/provision/tox.ini
+++ b/e2e/provision/tox.ini
@@ -35,7 +35,7 @@ commands = bash -c "find {toxinidir} \
    -not -path {toxinidir}/.tox/\* \
    -name \*.py | xargs vulture"
 
-[testenv:{bootstrap}]
+[testenv:{bootstrap,install}]
 deps = -r{toxinidir}/test-requirements.txt
 passenv = VAGRANT_*
 envdir = {toxinidir}/.tox/molecule


### PR DESCRIPTION
This Ansible role provides the tasks required for deploying Nephio services on target nodes, it consumes the tasks defined on the [kpt role](https://github.com/nephio-project/test-infra/tree/main/e2e/provision/playbooks/roles/kpt).

Related items:
* [Nephio installer](https://github.com/nephio-project/test-infra/tree/main/e2e/provision/playbooks/roles/kpt)
* [Nephio installation commands](https://github.com/nephio-project/nephio/issues/47#issuecomment-1524730928)