### PR TITLE
Add kpt ansible module

### DIFF
--- a/e2e/provision/.ansible-lint
+++ b/e2e/provision/.ansible-lint
@@ -14,6 +14,8 @@ skip_list:
   - experimental
 exclude_paths:
   - roles/deploy_mk8s/
+mock_modules:
+  - kpt
 mock_roles:
   - andrewrothstein.kubectl
   - andrewrothstein.docker_engine

--- a/e2e/provision/playbooks/library/kpt.py
+++ b/e2e/provision/playbooks/library/kpt.py
@@ -1,0 +1,478 @@
+#   Copyright (c) 2023 The Nephio Authors.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+
+import os
+import subprocess
+
+from ansible.module_utils.basic import AnsibleModule
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: kpt
+
+short_description: >
+  Module for managing kpt command from ansible tasks.
+description:
+  - A module for managing kpt instructions from ansible tasks.
+options:
+    repo_uri:
+        description:
+          - URI of a git repository containing 1 or more packages as
+            subdirectories.
+        required: false
+        type: str
+    pkg_path:
+        description:
+          - Path to remote subdirectory containing Kubernetes resource
+            configuration files or directories.
+        required: false
+        type: str
+    version:
+        description:
+          - A git tag, branch, ref or commit for the remote version of the
+            package to fetch. Defaults to the default branch of the repository.
+        required: false
+        type: str
+        default: None
+    local_dest_directory:
+        description:
+          - The local directory to write the package to.
+        required: false
+        default: .
+        type: str
+    strategy:
+        description:
+          - Defines which strategy should be used to update the package.
+        required: false
+        type: str
+        choices:
+          - resource-merge
+          - fast-forward
+          - force-delete-replace
+    directory:
+        description:
+          - Directory of the kpt package.
+        required: false
+        default: .
+        type: str
+    diff_type:
+        description:
+          - The type of changes.
+        required: false
+        default: local
+        type: str
+        choices:
+          - local
+          - remote
+          - combined
+          - 3way
+    diff_tool:
+        description:
+          - Command line diffing tool for showing the changes.
+        required: false
+        default: diff
+        type: str
+    diff_tool_opts:
+        description:
+          - Commandline options to use with the command line diffing tool.
+        required: false
+        type: str
+    allow_exec:
+        description:
+          - Allow executable binaries to run as function.
+        required: false
+        type: str
+    image_pull_policy:
+        description:
+          - If the image should be pulled before rendering the package(s).
+        required: false
+        type: str
+    output:
+        description:
+           - If specified, the output resources are written to provided location, if not specified, resources are modified in-place.
+        required: false
+        type: str
+    results_dir:
+        description:
+           - Path to a directory to write structured results.
+        required: false
+        type: str
+    force:
+        description:
+           - Forces the inventory values to be updated, even if they are already set.
+        required: false
+        type: bool
+    inventory_id:
+        description:
+           - Inventory identifier for the package.
+        required: false
+        type: str
+    name:
+        description:
+           - The name for the ResourceGroup resource that contains the inventory for the package.
+        required: false
+        type: str
+    namespace:
+        description:
+           - The namespace for the ResourceGroup resource that contains the inventory for the package.
+        required: false
+        type: str
+    rg_file:
+        description:
+           - The name used for the file created for the ResourceGroup CR.
+        required: false
+        type: str
+    dry_run:
+        description:
+           - It true, kpt will validate the resources in the package and print which resources will be applied and which resources will be pruned, but no resources will be changed.
+        required: false
+        type: bool
+    field_manager:
+        description:
+          - Identifier for the **owner** of the fields being applied.
+        required: false
+        type: str
+        default: kubectl
+    force_conflicts:
+        description:
+          - Force overwrite of field conflicts during apply due to different field managers.
+        required: false
+        type: bool
+    install_resource_group:
+        description:
+          - Install the ResourceGroup CRD into the cluster if it isn't already available.
+        required: false
+        type: bool
+    inventory_policy:
+        description:
+          - Determines how to handle overlaps between the package being currently applied and existing resources in the cluster.
+        required: false
+        type: str
+        choices:
+          - strict
+          - adopt
+    prune_propagation_policy:
+        description:
+          - The propagation policy that should be used when pruning resources
+        required: false
+        type: str
+        choices:
+          - Background
+          - Foreground
+          - Orphan
+    prune_timeout:
+        description:
+          - The threshold for how long to wait for all pruned resources to be deleted before giving up.
+        required: false
+        type: str
+    reconcile_timeout:
+        description:
+          - The threshold for how long to wait for all resources to reconcile before giving up.
+        required: false
+        type: str
+    server_side:
+        description:
+          - Perform the apply operation server-side rather than client-side.
+        required: false
+        type: bool
+    show_status_events:
+        description:
+          - The output will include the details on the reconciliation status for all resources.
+        required: false
+        type: bool
+    context:
+        description:
+          - The name of the kubeconfig context to use
+        required: false
+        type: str
+    command:
+        description:
+          - The command and subcommand to be executed.
+        required: true
+        choices:
+          - pkg-get
+          - pkg-tree
+          - pkg-diff
+          - fn-render
+          - live-init
+          - live-apply
+
+requirements:
+    - kpt >= 1.0.0-beta.32
+
+author:
+    - Victor Morales (@electrocucaracha)
+"""  # noqa: F841
+
+EXAMPLES = r"""
+- name: Fetch nephio-system package
+  kpt:
+    repo_uri: https://github.com/nephio-project/nephio-packages.git
+    pkg_path: nephio-system
+    version: @nephio-system/v6
+    local_dest_directory: /opt/nephio-system
+    command: pkg-get
+
+- name: Get nephio-system package content
+  kpt:
+    directory: /opt/nephio-system/
+    command: pkg-tree
+"""  # noqa: F841
+
+RETURN = r"""
+rc:
+    description: The command return code (0 means success)
+    returned: always
+    type: int
+cmd:
+    description: The command executed by the task
+    returned: always
+    type: str
+stdout:
+    description: The command standard output
+    returned: changed
+    type: str
+stdout_lines:
+    description: A list of strings, each containing one item per line from the original output.
+    returned: changed
+    type: str
+stderr:
+    description: Output on stderr
+    returned: changed
+    type: str
+stderr_lines:
+    description: A list of strings, each containing one item per line from the original error.
+    returned: changed
+    type: str
+"""  # noqa: F841
+
+
+class KptClient:
+    def __init__(self, module) -> None:
+        self._module = module
+        self._kpt_cmd_path = "/usr/local/bin/kpt"
+
+    def _run(self, cmd, changed=True):
+        result = dict(changed=False, rc=0, cmd=" ".join(cmd))
+        try:
+            kpt_result = subprocess.run(cmd, capture_output=True, text=True)
+            result["changed"] = changed
+            result["stdout"] = kpt_result.stdout
+            result["stdout_lines"] = kpt_result.stdout.splitlines()
+        except subprocess.CalledProcessError as kptexc:
+            result["rc"] = kptexc.returncode
+            result["stderr"] = kptexc.stderr
+            result["stderr_lines"] = kpt_result.stderr.splitlines()
+            self._module.fail_json(msg="Failed to fetch the package", **result)
+
+        self._module.exit_json(**result)
+
+    # Show resources in the current directory.
+    def pkg_tree(self, directory, **kargs):
+        cmd = [self._kpt_cmd_path, "pkg", "tree"]
+        if directory:
+            cmd.append(directory)
+        self._run(cmd, False)
+
+    # Fetch a package from a git repo.
+    def pkg_get(
+        self, repo_uri, pkg_path, local_dest_directory, version, strategy, **kargs
+    ):
+        cmd = [self._kpt_cmd_path, "pkg", "get"]
+        cmd.append(
+            "{}/{}{}".format(
+                repo_uri,
+                pkg_path,
+                "@" + version if version else "",
+            )
+        )
+        if local_dest_directory:
+            cmd.append(local_dest_directory)
+        if strategy and strategy in [
+            "resource-merge",
+            "fast-forward",
+            "force-delete-replace",
+        ]:
+            cmd.extend(["--strategy", strategy])
+
+        result = dict(changed=False, rc=0, cmd=" ".join(cmd))
+
+        dest = (
+            (local_dest_directory if local_dest_directory else ".")
+            + "/"
+            + pkg_path.split("/")[-1]
+        )
+        if not os.path.exists(dest):
+            self._run(cmd)
+        self._module.exit_json(**result)
+
+    # Show differences between a local package and upstream.
+    def pkg_diff(
+        self, pkg_path, version, diff_type, diff_tool, diff_tool_opts, **kargs
+    ):
+        cmd = [self._kpt_cmd_path, "pkg", "diff"]
+        if pkg_path:
+            cmd.append(
+                "{}{}".format(
+                    pkg_path,
+                    "@" + version if version else "",
+                )
+            )
+            cmd.append(pkg_path)
+        if diff_type and diff_type["local", "remote", "combined", "3way"]:
+            cmd.extend(["--diff-type", diff_type])
+        if diff_tool:
+            cmd.extend(["--diff-tool", diff_tool])
+        if diff_tool_opts:
+            cmd.extend(["--diff-tool-opts", diff_tool_opts])
+        self._run(cmd, False)
+
+    # Render a package.
+    def fn_render(
+        self, pkg_path, allow_exec, image_pull_policy, output, results_dir, **kargs
+    ):
+        cmd = [self._kpt_cmd_path, "fn", "render"]
+        if pkg_path:
+            cmd.append(pkg_path)
+        if allow_exec:
+            cmd.extend(["--allow-exec", allow_exec])
+        if image_pull_policy:
+            cmd.extend(["--image-pull-policy", image_pull_policy])
+        if output:
+            cmd.extend(["--output", output])
+        if results_dir:
+            cmd.extend(["--results-dir", results_dir])
+        self._run(cmd)
+
+    # Initialize a package with the information needed for inventory tracking.
+    def live_init(
+        self, pkg_path, force, inventory_id, name, namespace, rg_file, context, **kargs
+    ):
+        cmd = [self._kpt_cmd_path, "live", "init"]
+        if pkg_path:
+            cmd.append(pkg_path)
+        if force:
+            cmd.extend(["--force", force])
+        if inventory_id:
+            cmd.extend(["--inventory-id", inventory_id])
+        if name:
+            cmd.extend(["--name", name])
+        if namespace:
+            cmd.extend(["--namespace", namespace])
+        if rg_file:
+            cmd.extend(["--rg-file", rg_file])
+        if context:
+            cmd.extend(["--context", context])
+        self._run(cmd)
+
+    # Apply a package to the cluster (create, update, prune).
+    def live_apply(
+        self,
+        pkg_path,
+        dry_run,
+        field_manager,
+        force_conflicts,
+        install_resource_group,
+        inventory_policy,
+        output,
+        prune_propagation_policy,
+        prune_timeout,
+        reconcile_timeout,
+        server_side,
+        show_status_events,
+        context,
+        **kargs
+    ):
+        cmd = [self._kpt_cmd_path, "live", "apply"]
+        if pkg_path:
+            cmd.append(pkg_path)
+        if dry_run:
+            cmd.extend(["--dry-run", dry_run])
+        if field_manager:
+            cmd.extend(["--field-manager", field_manager])
+        if force_conflicts:
+            cmd.extend(["--force-conflicts", force_conflicts])
+        if install_resource_group:
+            cmd.extend(["--install-resource-group", install_resource_group])
+        if inventory_policy:
+            cmd.extend(["--inventory-policy", inventory_policy])
+        if output:
+            cmd.extend(["--output", output])
+        if prune_propagation_policy:
+            cmd.extend(["--prune-propagation-policy", prune_propagation_policy])
+        if prune_timeout:
+            cmd.extend(["--prune-timeout", prune_timeout])
+        if reconcile_timeout:
+            cmd.extend(["--reconcile-timeout", reconcile_timeout])
+        if server_side:
+            cmd.extend(["--server-side", server_side])
+        if show_status_events:
+            cmd.extend(["--show-status-events", show_status_events])
+        if context:
+            cmd.extend(["--context", context])
+        self._run(cmd)
+
+
+def main():
+    module_args = dict(
+        repo_uri=dict(type="str", required=False),
+        pkg_path=dict(type="str", required=False),
+        version=dict(type="str", required=False),
+        local_dest_directory=dict(type="str", required=False),
+        strategy=dict(type="str", required=False),
+        directory=dict(type="str", required=False),
+        diff_type=dict(type="bool", required=False),
+        diff_tool=dict(type="str", required=False),
+        diff_tool_opts=dict(type="str", required=False),
+        allow_exec=dict(type="str", required=False),
+        image_pull_policy=dict(type="str", required=False),
+        output=dict(type="str", required=False),
+        results_dir=dict(type="str", required=False),
+        force=dict(type="bool", required=False),
+        inventory_id=dict(type="str", required=False),
+        name=dict(type="str", required=False),
+        namespace=dict(type="str", required=False),
+        rg_file=dict(type="str", required=False),
+        dry_run=dict(type="bool", required=False),
+        field_manager=dict(type="str", required=False),
+        force_conflicts=dict(type="bool", required=False),
+        install_resource_group=dict(type="bool", required=False),
+        inventory_policy=dict(type="str", required=False),
+        prune_propagation_policy=dict(type="str", required=False),
+        prune_timeout=dict(type="str", required=False),
+        reconcile_timeout=dict(type="str", required=False),
+        server_side=dict(type="bool", required=False),
+        show_status_events=dict(type="bool", required=False),
+        context=dict(type="str", required=False),
+        command=dict(type="str", required=True),
+    )
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
+
+    client = KptClient(module)
+    functions = {
+        "pkg-get": client.pkg_get,
+        "pkg-tree": client.pkg_tree,
+        "pkg-diff": client.pkg_diff,
+        "fn-render": client.fn_render,
+        "live-init": client.live_init,
+        "live-apply": client.live_apply,
+    }
+    functions[module.params["command"]](**module.params)
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/provision/playbooks/roles/bootstrap/molecule/default/converge.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/molecule/default/converge.yml
@@ -14,7 +14,3 @@
     - name: Include bootstrap
       ansible.builtin.include_role:
         name: bootstrap
-      vars:
-        host_min_vcpu: 2
-        host_min_cpu_ram: 1
-        container_engine: docker

--- a/e2e/provision/playbooks/roles/bootstrap/molecule/default/molecule.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/molecule/default/molecule.yml
@@ -18,6 +18,8 @@ lint: |
   set -e
   PATH=${PATH}
   yamllint -c ../../../.yaml-lint.yml .
+  ansible-lint -v -c ../../../.ansible-lint
+  flake8
 platforms:
   - name: bionic
     box: generic/ubuntu2004
@@ -25,6 +27,13 @@ platforms:
       gui: false
 provisioner:
   name: ansible
+  env:
+    ANSIBLE_LIBRARY: ${MOLECULE_PROJECT_DIRECTORY}/../../../playbooks/library
+  inventory:
+    group_vars:
+      all:
+        host_min_vcpu: 2
+        host_min_cpu_ram: 1
 verifier:
   name: testinfra
   options:

--- a/e2e/provision/playbooks/roles/install/molecule/default/molecule.yml
+++ b/e2e/provision/playbooks/roles/install/molecule/default/molecule.yml
@@ -18,6 +18,8 @@ lint: |
   set -e
   PATH=${PATH}
   yamllint -c ../../../.yaml-lint.yml .
+  ansible-lint -v -c ../../../.ansible-lint
+  flake8
 platforms:
   - name: bionic
     box: generic/ubuntu2004
@@ -27,6 +29,8 @@ provisioner:
   name: ansible
   playbooks:
     prepare: ${MOLECULE_PROJECT_DIRECTORY}/../kpt/molecule/default/prepare.yml
+  env:
+    ANSIBLE_LIBRARY: ${MOLECULE_PROJECT_DIRECTORY}/../../../playbooks/library
 verifier:
   name: testinfra
   options:

--- a/e2e/provision/playbooks/roles/kpt/molecule/default/molecule.yml
+++ b/e2e/provision/playbooks/roles/kpt/molecule/default/molecule.yml
@@ -25,6 +25,8 @@ platforms:
       gui: false
 provisioner:
   name: ansible
+  env:
+    ANSIBLE_LIBRARY: ${MOLECULE_PROJECT_DIRECTORY}/../../../playbooks/library
   inventory:
     group_vars:
       all:

--- a/e2e/provision/playbooks/roles/kpt/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/kpt/tasks/main.yml
@@ -8,30 +8,29 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 ##############################################################################
 
-- name: Get base directory name
-  set_fact:
-    local_dest: "{{ local_dest_directory }}/{{ pkg }}"
-
 - name: Create base directory if it does not exist
   ansible.builtin.file:
-    path: "{{ local_dest | dirname }}"
+    path: "{{ local_dest_directory }}"
     state: directory
 
-- name: Check package exists
-  ansible.builtin.stat:
-    path: "{{ local_dest }}"
-  register: kpt_pkg_path
-
 - name: Fetch package
-  ansible.builtin.command: "kpt pkg get {{ repo_uri }}/{{ pkg }}@{{ version }} {{ local_dest }}"
-  when: not kpt_pkg_path.stat.exists
-  changed_when: false
+  kpt:
+    repo_uri: "{{ repo_uri }}"
+    pkg_path: "{{ pkg }}"
+    version: "{{ version }}"
+    local_dest_directory: "{{ local_dest_directory }}"
+    command: pkg-get
+
+- name: Get the local path
+  ansible.builtin.set_fact:
+    directory: "{{ local_dest_directory }}/{{ pkg | split('/') | last }}"
 
 - name: Get package content information
   become: true
-  ansible.builtin.command: "kpt pkg tree {{ local_dest }}"
+  kpt:
+    directory: "{{ directory }}"
+    command: pkg-tree
   register: kpt_pkg_tree
-  changed_when: false
 
 - name: Print package content information
   ansible.builtin.debug:
@@ -39,20 +38,24 @@
 
 - name: Check package has been initialized
   ansible.builtin.stat:
-    path: "{{ local_dest }}/resourcegroup.yaml"
+    path: "{{ directory }}/resourcegroup.yaml"
   register: kpt_resourcegroup
 
 # TODO: Improve the render function
 - name: Render package
   become: true
-  ansible.builtin.command: "kpt fn render {{ local_dest }}"
+  kpt:
+    pkg_path: "{{ directory }}"
+    command: fn-render
   when: not kpt_resourcegroup.stat.exists
 
 - name: Get package differences between local and upstream
   become: true
-  ansible.builtin.command: "kpt pkg diff {{ local_dest }}"
+  kpt:
+    pkg_path: "{{ directory }}"
+    version: "{{ version }}"
+    command: pkg-diff
   register: kpt_pkg_diff
-  changed_when: false
 
 - name: Print package differences
   ansible.builtin.debug:
@@ -60,9 +63,14 @@
 
 - name: Init package
   become: true
-  ansible.builtin.command: "kpt live init {{ local_dest }}"
-  when: not kpt_resourcegroup.stat.exists
+  kpt:
+    pkg_path: "{{ directory }}"
+    version: "{{ version }}"
+    context: "{{ context }}"
+    command: live-init
+  ignore_errors: true
   register: kpt_live_init
+  changed_when: false
 
 - name: Print package initialization
   ansible.builtin.debug:
@@ -70,7 +78,11 @@
 
 - name: Apply package
   become: true
-  ansible.builtin.command: "kpt live apply --reconcile-timeout=15m {{ local_dest }}"
+  kpt:
+    pkg_path: "{{ directory }}"
+    version: "{{ version }}"
+    context: "{{ context }}"
+    command: live-apply
   register: kpt_apply
   until: kpt_apply is not failed
   retries: 5


### PR DESCRIPTION
Wrapping the kpt client commands in to an ansible module can provide a better control on the output and avoid false positives during the execution. This change introduces the kpt ansible module.