### PR TITLE
Add molecule tests to kpt Ansible role

### DIFF
--- a/e2e/provision/playbooks/roles/kpt/README.md
+++ b/e2e/provision/playbooks/roles/kpt/README.md
@@ -1,0 +1,3 @@
+# kpt
+
+This ansible role gets, renders, initialializes and applies a given kpt package.

--- a/e2e/provision/playbooks/roles/kpt/molecule/default/converge.yml
+++ b/e2e/provision/playbooks/roles/kpt/molecule/default/converge.yml
@@ -8,26 +8,9 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 ##############################################################################
 
-dependency:
-  name: galaxy
-  options:
-    role-file: ../../../galaxy-requirements.yml
-driver:
-  name: vagrant
-lint: |
-  set -e
-  PATH=${PATH}
-  yamllint -c ../../../.yaml-lint.yml .
-platforms:
-  - name: bionic
-    box: generic/ubuntu2004
-    provider_options:
-      gui: false
-provisioner:
-  name: ansible
-  playbooks:
-    prepare: ${MOLECULE_PROJECT_DIRECTORY}/../kpt/molecule/default/prepare.yml
-verifier:
-  name: testinfra
-  options:
-    sudo: true
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Include install
+      ansible.builtin.include_role:
+        name: kpt

--- a/e2e/provision/playbooks/roles/kpt/molecule/default/molecule.yml
+++ b/e2e/provision/playbooks/roles/kpt/molecule/default/molecule.yml
@@ -25,8 +25,16 @@ platforms:
       gui: false
 provisioner:
   name: ansible
-  playbooks:
-    prepare: ${MOLECULE_PROJECT_DIRECTORY}/../kpt/molecule/default/prepare.yml
+  inventory:
+    group_vars:
+      all:
+        local_dest_directory: /tmp
+        pkg: package-examples/nginx
+        repo_uri: https://github.com/GoogleContainerTools/kpt
+        version: v0.9
+        context: kind-kind
+        namespaces:
+          - default
 verifier:
   name: testinfra
   options:

--- a/e2e/provision/playbooks/roles/kpt/molecule/default/prepare.yml
+++ b/e2e/provision/playbooks/roles/kpt/molecule/default/prepare.yml
@@ -44,19 +44,7 @@
       ansible.builtin.command: kind get clusters
       register: kind_get_cluster
       failed_when: (kind_get_cluster.rc not in [0, 1])
-      changed_when: false
-    - name: Create management cluster
+    - name: Create k8s cluster
       become: true
-      ansible.builtin.command: kind create cluster --config=-
-      args:
-        stdin: |
-          kind: Cluster
-          apiVersion: kind.x-k8s.io/v1alpha4
-          nodes:
-            - role: control-plane
-              image: kindest/node:v1.27.1
-              extraMounts:
-                - hostPath: /var/run/docker.sock
-                  containerPath: /var/run/docker.sock
+      ansible.builtin.command: kind create cluster --image kindest/node:v1.27.1
       when: not 'kind' in kind_get_cluster.stdout
-      changed_when: true

--- a/e2e/provision/playbooks/roles/kpt/molecule/default/tests/test_default.py
+++ b/e2e/provision/playbooks/roles/kpt/molecule/default/tests/test_default.py
@@ -1,0 +1,31 @@
+#   Copyright (c) 2023 The Nephio Authors.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+
+
+def test_deployments(host):
+    got = host.check_output(
+        "sudo kubectl get deploy --no-headers -o custom-columns=':metadata.name'"
+    )
+    assert "my-nginx" == got
+    cmd = host.run("sudo kubectl rollout status deployment/my-nginx")
+    assert cmd.succeeded
+    assert cmd.rc == 0
+
+
+def test_services(host):
+    got = host.check_output(
+        "sudo kubectl get service --no-headers -o custom-columns=':metadata.name'"
+    )
+    assert "my-nginx-svc" in got

--- a/e2e/provision/playbooks/roles/kpt/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/kpt/tasks/main.yml
@@ -8,19 +8,28 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 ##############################################################################
 
+- name: Get base directory name
+  set_fact:
+    local_dest: "{{ local_dest_directory }}/{{ pkg }}"
+
+- name: Create base directory if it does not exist
+  ansible.builtin.file:
+    path: "{{ local_dest | dirname }}"
+    state: directory
+
 - name: Check package exists
   ansible.builtin.stat:
-    path: "{{ local_dest_directory }}/{{ pkg }}"
+    path: "{{ local_dest }}"
   register: kpt_pkg_path
 
 - name: Fetch package
-  ansible.builtin.command: "kpt pkg get {{ repo_uri }}/{{ pkg }}@{{ version }} {{ local_dest_directory }}/{{ pkg }}"
+  ansible.builtin.command: "kpt pkg get {{ repo_uri }}/{{ pkg }}@{{ version }} {{ local_dest }}"
   when: not kpt_pkg_path.stat.exists
   changed_when: false
 
 - name: Get package content information
   become: true
-  ansible.builtin.command: "kpt pkg tree {{ local_dest_directory }}/{{ pkg }}"
+  ansible.builtin.command: "kpt pkg tree {{ local_dest }}"
   register: kpt_pkg_tree
   changed_when: false
 
@@ -28,15 +37,20 @@
   ansible.builtin.debug:
     var: kpt_pkg_tree.stdout_lines
 
+- name: Check package has been initialized
+  ansible.builtin.stat:
+    path: "{{ local_dest }}/resourcegroup.yaml"
+  register: kpt_resourcegroup
+
 # TODO: Improve the render function
 - name: Render package
   become: true
-  ansible.builtin.command: "kpt fn render {{ local_dest_directory }}/{{ pkg }}"
-  changed_when: false
+  ansible.builtin.command: "kpt fn render {{ local_dest }}"
+  when: not kpt_resourcegroup.stat.exists
 
 - name: Get package differences between local and upstream
   become: true
-  ansible.builtin.command: "kpt pkg diff {{ local_dest_directory }}/{{ pkg }}"
+  ansible.builtin.command: "kpt pkg diff {{ local_dest }}"
   register: kpt_pkg_diff
   changed_when: false
 
@@ -46,9 +60,8 @@
 
 - name: Init package
   become: true
-  ansible.builtin.command: "kpt live init {{ local_dest_directory }}/{{ pkg }}"
-  changed_when: false
-  ignore_errors: true
+  ansible.builtin.command: "kpt live init {{ local_dest }}"
+  when: not kpt_resourcegroup.stat.exists
   register: kpt_live_init
 
 - name: Print package initialization
@@ -57,7 +70,7 @@
 
 - name: Apply package
   become: true
-  ansible.builtin.command: "kpt live apply --reconcile-timeout=15m {{ local_dest_directory }}/{{ pkg }}"
+  ansible.builtin.command: "kpt live apply --reconcile-timeout=15m {{ local_dest }}"
   register: kpt_apply
   until: kpt_apply is not failed
   retries: 5

--- a/e2e/provision/tox.ini
+++ b/e2e/provision/tox.ini
@@ -35,7 +35,7 @@ commands = bash -c "find {toxinidir} \
    -not -path {toxinidir}/.tox/\* \
    -name \*.py | xargs vulture"
 
-[testenv:{bootstrap,install}]
+[testenv:{kpt,bootstrap,install}]
 deps = -r{toxinidir}/test-requirements.txt
 passenv = VAGRANT_*
 envdir = {toxinidir}/.tox/molecule


### PR DESCRIPTION
The `kpt` Ansible role is used as helper for some tasks defined in the `bootstrap` and `install` Ansible roles. The initial version didn't have unit tests and documentation. This change provides some information and integration tests.