### PR TITLE
Deploy gitea services in a separated cluster

### DIFF
--- a/e2e/provision/playbooks/roles/bootstrap/defaults/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/defaults/main.yml
@@ -15,8 +15,35 @@ host_min_root_disk_space: 50  # minimum required disk space before install; valu
 container_engine: docker
 kubernetes_version: v1.27.1
 
-gitea_postgres_password: c2VjcmV0Cg==  # echo "secret" | base64
-gitea_db_password: c2VjcmV0Cg==
+kpt_local_dest: /tmp
 
-gitea_username: admin
-gitea_password: secret
+gitea:
+  enabled: true
+  k8s:
+    cluster_name: gitea-k8s  # cluster names must match `^[a-z0-9.-]+$`
+    namespace: gitea
+    postgres_password: c2VjcmV0Cg==  # echo "secret" | base64
+    db_password: c2VjcmV0Cg==
+    username: admin
+    password: secret
+  kpt:
+    packages:
+      - repo_uri: https://github.com/nephio-project/nephio-example-packages
+        pkg: gitea
+        version: gitea/v1
+
+cluster_api:
+  enabled: true
+  k8s:
+    cluster_name: mgmt-k8s  # cluster names must match `^[a-z0-9.-]+$`
+  kpt:
+    packages:
+      - repo_uri: https://github.com/nephio-project/nephio-example-packages
+        pkg: cert-manager
+        version: cert-manager/v1
+      - repo_uri: https://github.com/nephio-project/nephio-example-packages
+        pkg: cluster-capi
+        version: cluster-capi/v1
+      - repo_uri: https://github.com/nephio-project/nephio-example-packages
+        pkg: cluster-capi-infrastructure-docker
+        version: cluster-capi-infrastructure-docker/v1

--- a/e2e/provision/playbooks/roles/bootstrap/molecule/default/tests/test_default.py
+++ b/e2e/provision/playbooks/roles/bootstrap/molecule/default/tests/test_default.py
@@ -14,19 +14,33 @@
 #
 
 
-def test_kind_creation(host):
-    kind = host.docker("kind-control-plane")
+def test_kind_clusters_creation(host):
+    cmd = host.run("sudo kind get clusters")
+    assert cmd.succeeded
+    assert cmd.rc == 0
+    assert "gitea-k8s" in cmd.stdout
+    assert "mgmt-k8s" in cmd.stdout
+
+
+def test_gitea_cluster_creation(host):
+    kind = host.docker("gitea-k8s-control-plane")
+
+    assert kind.is_running
+
+
+def test_mgmt_cluster_mounted_docker_host_sock(host):
+    kind = host.docker("mgmt-k8s-control-plane")
 
     assert kind.is_running
     destinations = host.check_output(
         "docker inspect \
 --format '{{range .Mounts }}{{.Destination}}{{\"\\n\"}}{{end}}' \
-kind-control-plane"
+mgmt-k8s-control-plane"
     )
     assert "/var/run/docker.sock" in destinations
     sources = host.check_output(
         "docker inspect \
 --format '{{range .Mounts }}{{.Source}}{{\"\\n\"}}{{end}}' \
-kind-control-plane"
+mgmt-k8s-control-plane"
     )
     assert "/var/run/docker.sock" in sources

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/gitea.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/gitea.yml
@@ -1,0 +1,84 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+- name: Get k8s clusters
+  become: true
+  ansible.builtin.command: kind get clusters
+  register: bootstrap_kind_get_cluster
+  failed_when: (bootstrap_kind_get_cluster.rc not in [0, 1])
+  changed_when: false
+
+- name: Print kind_get_cluster value
+  ansible.builtin.debug:
+    var: bootstrap_kind_get_cluster
+
+- name: Create gitea cluster
+  become: true
+  ansible.builtin.command: >
+    kind create cluster --name {{ gitea.k8s.cluster_name }}
+    --image kindest/node:{{ kubernetes_version }}
+  when: not gitea.k8s.cluster_name in bootstrap_kind_get_cluster.stdout
+
+- name: Create gitea namespace
+  become: true
+  kubernetes.core.k8s:
+    context: "kind-{{ gitea.k8s.cluster_name }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ gitea.k8s.namespace }}"
+
+- name: Create gitea postgresql user password
+  become: true
+  kubernetes.core.k8s:
+    context: "kind-{{ gitea.k8s.cluster_name }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: gitea-postgresql
+        namespace: "{{ gitea.k8s.namespace }}"
+        labels:
+          app.kubernetes.io/name: postgresql
+          app.kubernetes.io/instance: gitea
+      type: Opaque
+      data:
+        postgres-password: "{{ gitea.k8s.postgres_password }}"
+        password: "{{ gitea.k8s.db_password }}"
+
+- name: Create gitea user password
+  become: true
+  kubernetes.core.k8s:
+    context: "kind-{{ gitea.k8s.cluster_name }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: git-user-secret
+        namespace: "{{ gitea.k8s.namespace }}"
+      type: kubernetes.io/basic-auth
+      stringData:
+        username: "{{ gitea.k8s.username }}"
+        password: "{{ gitea.k8s.password }}"
+
+- name: Deploy gitea packages
+  ansible.builtin.include_role:
+    name: kpt
+  loop: "{{ gitea.kpt.packages }}"
+  vars:
+    context: "kind-{{ gitea.k8s.cluster_name }}"
+    repo_uri: "{{ item.repo_uri }}"
+    local_dest_directory: "{{ kpt_local_dest }}"
+    pkg: "{{ item.pkg }}"
+    version: "{{ item.version }}"

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
@@ -11,86 +11,10 @@
 - name: Check Host requirements
   ansible.builtin.include_tasks: prechecks.yml
 
-- name: Get k8s clusters
-  become: true
-  ansible.builtin.command: kind get clusters
-  register: bootstrap_kind_get_cluster
-  failed_when: (bootstrap_kind_get_cluster.rc not in [0, 1])
-  changed_when: false
+- name: Deploy gitea cluster
+  ansible.builtin.include_tasks: gitea.yml
+  when: gitea.enabled|default(true)|bool
 
-- name: Print kind_get_cluster value
-  ansible.builtin.debug:
-    var: bootstrap_kind_get_cluster
-
-- name: Create management cluster
-  become: true
-  ansible.builtin.command: kind create cluster --config=-
-  args:
-    stdin: |
-      kind: Cluster
-      apiVersion: kind.x-k8s.io/v1alpha4
-      nodes:
-        - role: control-plane
-          image: kindest/node:{{ kubernetes_version }}
-          extraMounts:
-            - hostPath: /var/run/{{ container_engine }}.sock
-              containerPath: /var/run/{{ container_engine }}.sock
-  when: not 'kind' in bootstrap_kind_get_cluster.stdout
-  changed_when: true
-
-- name: Create gitea namespace
-  become: true
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: gitea
-
-- name: Create gitea postgresql user password
-  become: true
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: gitea-postgresql
-        namespace: gitea
-        labels:
-          app.kubernetes.io/name: postgresql
-          app.kubernetes.io/instance: gitea
-      type: Opaque
-      data:
-        postgres-password: "{{ gitea_postgres_password }}"
-        password: "{{ gitea_db_password }}"
-
-- name: Create gitea user password
-  become: true
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: git-user-secret
-        namespace: gitea
-      type: kubernetes.io/basic-auth
-      stringData:
-        username: "{{ gitea_username }}"
-        password: "{{ gitea_password }}"
-
-- name: Deploy base packages
-  ansible.builtin.include_role:
-    name: kpt
-  loop:
-    - {pkg: gitea, version: gitea/v1}
-    - {pkg: cert-manager, version: cert-manager/v1}
-    - {pkg: cluster-capi, version: cluster-capi/v1}
-    - {pkg: cluster-capi-infrastructure-docker, version: cluster-capi-infrastructure-docker/v1}
-  vars:
-    repo_uri: https://github.com/nephio-project/nephio-example-packages
-    local_dest_directory: /tmp
-    pkg: "{{ item.pkg }}"
-    version: "{{ item.version }}"
+- name: Deploy managment cluster
+  ansible.builtin.include_tasks: mgmt.yml
+  when: cluster_api.enabled|default(true)|bool

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/mgmt.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/mgmt.yml
@@ -1,0 +1,48 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+- name: Get k8s clusters
+  become: true
+  ansible.builtin.command: kind get clusters
+  register: bootstrap_kind_get_cluster
+  failed_when: (bootstrap_kind_get_cluster.rc not in [0, 1])
+  changed_when: false
+
+- name: Print kind_get_cluster value
+  ansible.builtin.debug:
+    var: bootstrap_kind_get_cluster
+
+- name: Create management cluster
+  become: true
+  ansible.builtin.command: >
+    kind create cluster --name {{ cluster_api.k8s.cluster_name }}
+    --config=-
+  args:
+    stdin: |
+      kind: Cluster
+      apiVersion: kind.x-k8s.io/v1alpha4
+      nodes:
+        - role: control-plane
+          image: kindest/node:{{ kubernetes_version }}
+          extraMounts:
+            - hostPath: /var/run/{{ container_engine }}.sock
+              containerPath: /var/run/{{ container_engine }}.sock
+  when: not cluster_api.k8s.cluster_name in bootstrap_kind_get_cluster.stdout
+
+- name: Deploy cluster api packages
+  ansible.builtin.include_role:
+    name: kpt
+  loop: "{{ cluster_api.kpt.packages }}"
+  vars:
+    context: "kind-{{ cluster_api.k8s.cluster_name }}"
+    repo_uri: "{{ item.repo_uri }}"
+    local_dest_directory: "{{ kpt_local_dest }}"
+    pkg: "{{ item.pkg }}"
+    version: "{{ item.version }}"

--- a/e2e/provision/playbooks/roles/install/defaults/main.yml
+++ b/e2e/provision/playbooks/roles/install/defaults/main.yml
@@ -8,30 +8,15 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 ##############################################################################
 
-dependency:
-  name: galaxy
-  options:
-    role-file: ../../../galaxy-requirements.yml
-driver:
-  name: vagrant
-lint: |
-  set -e
-  PATH=${PATH}
-  yamllint -c ../../../.yaml-lint.yml .
-platforms:
-  - name: bionic
-    box: generic/ubuntu2004
-    provider_options:
-      gui: false
-provisioner:
-  name: ansible
-  inventory:
-    group_vars:
-      all:
-        k8s:
-          context: kind-kind
-verifier:
-verifier:
-  name: testinfra
-  options:
-    sudo: true
+kpt_local_dest: /tmp
+
+k8s:
+  context: kind-mgmt-k8s
+kpt:
+  packages:
+    - repo_uri: https://github.com/nephio-project/nephio-packages
+      pkg: nephio-system
+      version: nephio-system/v6
+    - repo_uri: https://github.com/nephio-project/nephio-packages
+      pkg: nephio-webui
+      version: nephio-webui/v6

--- a/e2e/provision/playbooks/roles/install/molecule/default/prepare.yml
+++ b/e2e/provision/playbooks/roles/install/molecule/default/prepare.yml
@@ -47,16 +47,5 @@
       changed_when: false
     - name: Create management cluster
       become: true
-      ansible.builtin.command: kind create cluster --config=-
-      args:
-        stdin: |
-          kind: Cluster
-          apiVersion: kind.x-k8s.io/v1alpha4
-          nodes:
-            - role: control-plane
-              image: kindest/node:v1.27.1
-              extraMounts:
-                - hostPath: /var/run/docker.sock
-                  containerPath: /var/run/docker.sock
+      ansible.builtin.command: kind create cluster
       when: not 'kind' in kind_get_cluster.stdout
-      changed_when: true

--- a/e2e/provision/playbooks/roles/install/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/install/tasks/main.yml
@@ -11,11 +11,10 @@
 - name: Deploy Nephio packages
   ansible.builtin.include_role:
     name: kpt
-  loop:
-    - {pkg: nephio-system, version: nephio-system/v6}
-    - {pkg: nephio-webui, version: nephio-webui/v6}
+  loop: "{{ kpt.packages }}"
   vars:
-    repo_uri: https://github.com/nephio-project/nephio-packages
-    local_dest_directory: /tmp
+    context: "{{ k8s.context }}"
+    repo_uri: "{{ item.repo_uri }}"
+    local_dest_directory: "{{ kpt_local_dest }}"
     pkg: "{{ item.pkg }}"
     version: "{{ item.version }}"

--- a/e2e/provision/playbooks/roles/kpt/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/kpt/tasks/main.yml
@@ -46,7 +46,7 @@
 
 - name: Init package
   become: true
-  ansible.builtin.command: "kpt live init {{ local_dest_directory }}/{{ pkg }}"
+  ansible.builtin.command: "kpt live init --context {{ context }} {{ local_dest_directory }}/{{ pkg }}"
   changed_when: false
   ignore_errors: true
   register: kpt_live_init
@@ -57,7 +57,7 @@
 
 - name: Apply package
   become: true
-  ansible.builtin.command: "kpt live apply --reconcile-timeout=15m {{ local_dest_directory }}/{{ pkg }}"
+  ansible.builtin.command: "kpt live apply --reconcile-timeout=15m --context {{ context }} {{ local_dest_directory }}/{{ pkg }}"
   register: kpt_apply
   until: kpt_apply is not failed
   retries: 5


### PR DESCRIPTION
In other to facilitate the access to Git server repositories, makes sense to separate Gitea services on their own cluster. This change adjust the `bootstrap` role to deploy two KinD clusters.