### PR TITLE
Add gce_init.sh startup script and revise instructions

### DIFF
--- a/e2e/provision/README.md
+++ b/e2e/provision/README.md
@@ -2,48 +2,65 @@
 
 1. Create a VM:
 
-```bash
-$ gcloud compute instances create --machine-type e2-standard-8 --boot-disk-size 60GB nephio-r1-e2e
-```
+   ```bash
+   $ gcloud compute instances create --machine-type e2-standard-8 \
+                                     --boot-disk-size 200GB \
+                                     --image-family=ubuntu-2004-lts \
+                                     --image-project=ubuntu-os-cloud \
+                                     --metadata=startup-script-url=https://raw.githubusercontent.com/nephio-project/test-infra/main/e2e/provision/gce_init.sh \
+                                     nephio-r1-e2e
+   ```
 
-2. SSH to the VM:
+2. If you want to watch the progress of the installation, give it about 30
+   seconds to reach a network accessible state, and then ssh in and tail the
+   startup script exection:
 
-Googlers (you also need to run `gcert`):
-```bash
-$ gcloud compute ssh nephio-r1-e2e -- -o ProxyCommand='corp-ssh-helper %h %p' -L 7007:localhost:7007
-```
+   Googlers (you also need to run `gcert`):
+   ```bash
+   $ gcloud compute ssh nephio-r1-e2e -- \
+                    -o ProxyCommand='corp-ssh-helper %h %p' \
+                    sudo journalctl -u google-startup-scripts.service --follow
+   ```
+   
+   Everyone else:
+   ```bash
+   $ gcloud compute ssh nephio-r1-e2e -- \
+                    sudo journalctl -u google-startup-scripts.service --follow
+   ```
 
-Everyone else:
-```bash
-$ gcloud compute ssh nephio-r1-e2e -- -L 7007:localhost:7007
-```
+4. Once it's done, ssh in and port forward the port to the UI:
 
-3. On the machine, run this:
+   Googlers (you also need to run `gcert`):
+   ```bash
+   $ gcloud compute ssh nephio-r1-e2e -- \
+                    -o ProxyCommand='corp-ssh-helper %h %p' \
+                    -L 7007:localhost:7007 \
+                    kubectl --kubeconfig /home/ubuntu/.kube/mgmt-config port-forward --namespace=nephio-webui svc/nephio-webui 7007
+   ```
+   
+   Everyone else:
+   ```bash
+   $ gcloud compute ssh nephio-r1-e2e -- \
+                    -L 7007:localhost:7007 \
+                    kubectl --kubeconfig /home/ubuntu/.kube/mgmt-config port-forward --namespace=nephio-webui svc/nephio-webui 7007
+   ```
+   
+   You can now navigate to
+   [http://localhost:7007/config-as-data](http://localhost:7007/config-as-data) to
+   browse the UI.
 
-```bash
-$ sudo apt-get install -y git
-$ git clone https://github.com/nephio-project/test-infra.git
-$ sed -e "s/vagrant/$USER/" < test-infra/e2e/provision/nephio.yaml > ~/nephio.yaml
-$ cd test-infra/e2e/provision/
-$ ./gce_run.sh
-$ kubectl --kubeconfig ~/.kube/mgmt-config port-forward --namespace=nephio-webui svc/nephio-webui 7007
-```
-
-You can now navigate to
-[http://localhost:7007/config-as-data](http://localhost:7007/config-as-data) to
-browse the UI.
-
-You probably want a second ssh window open to run `kubectl` commands, etc.,
+5. You probably want a second ssh window open to run `kubectl` commands, etc.,
 without the port forwarding (which would fail if you try to open a second ssh
 connection with that setting).
 
-Googlers:
-```bash
-$ gcloud compute ssh nephio-r1-e2e -- -o ProxyCommand='corp-ssh-helper %h %p'
-```
-
-Everyone else:
-```bash
-$ gcloud compute ssh nephio-r1-e2e
-```
-
+   Googlers:
+   ```bash
+   $ gcloud compute ssh nephio-r1-e2e -- -o ProxyCommand='corp-ssh-helper %h %p'
+   $ sudo su - ubuntu
+   ```
+   
+   Everyone else:
+   ```bash
+   $ gcloud compute ssh nephio-r1-e2e
+   $ sudo su - ubuntu
+   ```

--- a/e2e/provision/README.md
+++ b/e2e/provision/README.md
@@ -1,15 +1,20 @@
 # Quick Start for GCE
 
 1. Create a VM:
-
+   
    ```bash
    $ gcloud compute instances create --machine-type e2-standard-8 \
                                      --boot-disk-size 200GB \
-                                     --image-family=ubuntu-2004-lts \
+                                     --image-family=ubuntu-2204-lts \
                                      --image-project=ubuntu-os-cloud \
                                      --metadata=startup-script-url=https://raw.githubusercontent.com/nephio-project/test-infra/main/e2e/provision/gce_init.sh \
                                      nephio-r1-e2e
    ```
+
+   Note that this creates the default type, which as of right now is based on
+   teh workshop code. You can create an R1-based version by passing
+   `--metadata=nephio-setup-type=r1`. You can also enable the setup debug option
+   with `--metadata=nephio-setup-debug=true`.
 
 2. If you want to watch the progress of the installation, give it about 30
    seconds to reach a network accessible state, and then ssh in and tail the

--- a/e2e/provision/gce_init.sh
+++ b/e2e/provision/gce_init.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+DEBUG=$(curl -sf http://metadata.google.internal/computeMetadata/v1/instance/attributes/nephio-setup-debug -H "Metadata-Flavor: Google")
+DEPLOYMENT_TYPE=$(curl -sf http://metadata.google.internal/computeMetadata/v1/instance/attributes/nephio-setup-type -H "Metadata-Flavor: Google")
+
+set -o pipefail
+set -o errexit
+set -o nounset
+
+[[ "${DEBUG:-false}" != "true" ]] || set -o xtrace
+
+apt-get update
+
+if ! command -v gcc >/dev/null; then
+    if [[ $(uname -v) == *22.04.*-Ubuntu* ]]; then
+      apt-get -y install gcc-12
+    else
+      apt-get -y install gcc
+    fi
+fi
+
+apt-get install -y git
+cd /home/ubuntu
+runuser -u ubuntu git clone https://github.com/nephio-project/test-infra.git
+
+sed -e "s/vagrant/ubuntu/" < /home/ubuntu/test-infra/e2e/provision/nephio.yaml > /home/ubuntu/nephio.yaml
+export DEBUG DEPLOYMENT_TYPE
+cd ./test-infra/e2e/provision
+runuser -u ubuntu ./gce_run.sh


### PR DESCRIPTION
Added a startup script, so the user can launch Nephio Sandbox in a single gcloud command.