### PR TITLE
Proposal to reuse e2e and lab terraform scripts

### DIFF
--- a/e2e/provision/gce_install_sandbox.sh
+++ b/e2e/provision/gce_install_sandbox.sh
@@ -41,9 +41,9 @@ function deploy_kpt_pkg {
 
 sudo apt-get clean
 sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install python3-venv python3-pip -y
+sudo DEBIAN_FRONTEND=noninteractive apt-get install python3-virtualenv python3-pip -y
 
-python3 -m venv "$HOME/.venv"
+virtualenv "$HOME/.venv"
 # shellcheck disable=SC1091
 source "$HOME/.venv/bin/activate"
 pip install -r requirements.txt

--- a/e2e/terraform/main.tf
+++ b/e2e/terraform/main.tf
@@ -1,14 +1,14 @@
 provider "google" {
-  project = var.project
-  region  = var.region
-  zone    = var.zone
-  credentials = "${file(var.credentials)}"
+  project     = var.project
+  region      = var.region
+  zone        = var.zone
+  credentials = file(var.credentials)
 }
 
 resource "random_string" "vm-name" {
   length  = 6
   upper   = false
-  numeric  = false
+  numeric = false
   lower   = true
   special = false
 }
@@ -18,13 +18,13 @@ locals {
 }
 
 resource "google_compute_instance" "vm_instance" {
-  name         = local.vm-name
-  machine_type = var.instance
+  name                      = local.vm-name
+  machine_type              = var.instance
   allow_stopping_for_update = true
   metadata = {
-  ssh-keys = "${var.ansible_user}:${file(var.ssh_pub_key)}"
-  metadata_startup_script = file("${path.module}/../provision/gce_init.sh")
-  nephio-run-e2e = true
+    ssh-keys                = "${var.ansible_user}:${file(var.ssh_pub_key)}"
+    metadata_startup_script = file("${path.module}/../provision/gce_init.sh")
+    nephio-run-e2e          = true
   }
   boot_disk {
     initialize_params {

--- a/e2e/terraform/main.tf
+++ b/e2e/terraform/main.tf
@@ -25,7 +25,7 @@ resource "google_compute_instance" "lab_instances" {
   metadata = {
     ssh-keys                = "${var.ansible_user}:${file(var.ssh_pub_key)}"
     metadata_startup_script = file("${path.module}/../provision/gce_init.sh")
-    nephio-run-e2e          = true
+    nephio-run-e2e          = false
   }
   boot_disk {
     initialize_params {

--- a/e2e/terraform/main.tf
+++ b/e2e/terraform/main.tf
@@ -17,8 +17,9 @@ locals {
   vm-name = "e2e-vm-${random_string.vm-name.result}"
 }
 
-resource "google_compute_instance" "vm_instance" {
-  name                      = local.vm-name
+resource "google_compute_instance" "lab_instances" {
+  count                     = var.nephio_lab_nodes
+  name                      = "nephio-lab"
   machine_type              = var.instance
   allow_stopping_for_update = true
   metadata = {
@@ -32,12 +33,67 @@ resource "google_compute_instance" "vm_instance" {
       size  = 200
     }
   }
-
   network_interface {
     network = "default"
     access_config {
     }
   }
-
 }
 
+resource "google_compute_instance" "e2e_instances" {
+  count                     = var.nephio_e2e_nodes
+  name                      = local.vm-name
+  machine_type              = var.instance
+  allow_stopping_for_update = true
+  metadata = {
+    ssh-keys = "${var.ansible_user}:${file(var.ssh_pub_key)}"
+  }
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2004-lts"
+      size  = 200
+    }
+  }
+  network_interface {
+    network = "default"
+    access_config {
+    }
+  }
+  provisioner "file" {
+    source      = "../provision"
+    destination = "/home/ubuntu/provision"
+    connection {
+      host        = self.network_interface[0].access_config[0].nat_ip
+      type        = "ssh"
+      private_key = file(var.ssh_prv_key)
+      user        = var.ansible_user
+      agent       = false
+    }
+  }
+  provisioner "file" {
+    source      = "/etc/nephio/nephio.yaml"
+    destination = "/home/ubuntu/nephio.yaml"
+    connection {
+      host        = self.network_interface[0].access_config[0].nat_ip
+      type        = "ssh"
+      private_key = file(var.ssh_prv_key)
+      user        = var.ansible_user
+      agent       = false
+    }
+  }
+  provisioner "remote-exec" {
+    connection {
+      host        = self.network_interface[0].access_config[0].nat_ip
+      type        = "ssh"
+      private_key = file(var.ssh_prv_key)
+      user        = var.ansible_user
+      agent       = false
+    }
+    inline = [
+      "cd provision/",
+      "chmod +x gce_install_sandbox.sh",
+      "export DEBUG=true",
+      "timeout --preserve-status 30m ./gce_install_sandbox.sh"
+    ]
+  }
+}

--- a/e2e/terraform/output.tf
+++ b/e2e/terraform/output.tf
@@ -1,4 +1,4 @@
 output "instance_ips" {
-  value       = join(" ", google_compute_instance.vm_instance.*.network_interface.0.access_config.0.nat_ip)
+  value       = join(" ", google_compute_instance.lab_instances.*.network_interface.0.access_config.0.nat_ip)
   description = "The public IP address of the newly created instance"
 }

--- a/e2e/terraform/output.tf
+++ b/e2e/terraform/output.tf
@@ -1,4 +1,4 @@
 output "instance_ips" {
-  value = "${join(" ", google_compute_instance.vm_instance.*.network_interface.0.access_config.0.nat_ip)}"
+  value       = join(" ", google_compute_instance.vm_instance.*.network_interface.0.access_config.0.nat_ip)
   description = "The public IP address of the newly created instance"
 }

--- a/e2e/terraform/variables.tf
+++ b/e2e/terraform/variables.tf
@@ -29,3 +29,15 @@ variable "ssh_pub_key" {
 variable "ansible_user" {
   default = "ubuntu"
 }
+
+variable "nephio_lab_nodes" {
+  default     = 0
+  type        = number
+  description = "The number of Lab instances to be created."
+}
+
+variable "nephio_e2e_nodes" {
+  default     = 1
+  type        = number
+  description = "The number of End-to-End instances running per PR."
+}

--- a/e2e/terraform/variables.tf
+++ b/e2e/terraform/variables.tf
@@ -1,5 +1,5 @@
 variable "project" {
-    default = "pure-faculty-367518"
+  default = "pure-faculty-367518"
 }
 
 variable "region" {
@@ -7,7 +7,7 @@ variable "region" {
 }
 
 variable "zone" {
-    default = "us-central1-c"
+  default = "us-central1-c"
 }
 
 variable "instance" {


### PR DESCRIPTION
Both process uses the same amount of cloud resources with the major distinction to consume different sources. This change provides a new set of Terraform variables to control the number of `e2e` and `lab` instances. Ideally, they shouldn't have the same value, but maybe there are cases when both instances are needed

> Note, the format of the scripts were fixed with `terraform fmt`