### PR TITLE
Enable the Free5GC operator to be deployed on all workload clusters

### DIFF
--- a/e2e/tests/004-free5gc-operator.yaml
+++ b/e2e/tests/004-free5gc-operator.yaml
@@ -1,7 +1,7 @@
 apiVersion: config.porch.kpt.dev/v1alpha2
 kind: PackageVariantSet
 metadata:
-  name: edge-free5gc-operator
+  name: free5gc-operator
 spec:
   upstream:
     repo: free5gc-packages
@@ -11,8 +11,6 @@ spec:
   - objectSelector:
       apiVersion: infra.nephio.org/v1alpha1
       kind: WorkloadCluster
-      matchLabels:
-        nephio.org/site-type: edge
     template:
       annotations:
         approval.nephio.org/policy: initial


### PR DESCRIPTION
Enable the Free5GC operator to be deployed on all workload clusters
- Remove 'edge' in name
- Remove matching labels in 'objectSelector'