### PR TITLE
Add ubuntu user to docker group

### DIFF
--- a/e2e/provision/gce_init.sh
+++ b/e2e/provision/gce_init.sh
@@ -30,6 +30,11 @@ BRANCH=$(get_metadata nephio-test-infra-branch "main")
 
 echo "$DEBUG, $DEPLOYMENT_TYPE, $RUN_E2E, $REPO, $BRANCH"
 
+# pre-configure the "docker" group and add the "ubuntu" user to it so that the docker
+# and kpt fn apply commands will work without sudo
+addgroup docker
+usermod -a -G docker ubuntu
+
 apt-get update
 apt-get install -y git
 

--- a/e2e/provision/gce_install_sandbox.sh
+++ b/e2e/provision/gce_install_sandbox.sh
@@ -22,8 +22,7 @@ function deploy_kpt_pkg {
   local temp=$(mktemp -d -t kpt-XXXX)
   local localpkg="$temp/$name"
   kpt pkg get --for-deployment "https://github.com/nephio-project/nephio-example-packages.git/$pkg" "$localpkg"
-  # sudo because docker
-  sudo kpt fn render "$localpkg"
+  kpt fn render "$localpkg"
   kpt live init "$localpkg"
   kubectl --kubeconfig "$HOME/.kube/config" api-resources
   #kpt pkg tree "$localpkg"


### PR DESCRIPTION
This change pre-provisions the "docker" group and adds the "ubuntu" user to it. Hhus, the "ubuntu" user has permission to run docker and kpt fn render commands without sudo.