### PR TITLE
Vagrant Sandbox provisioning support for Windows

### DIFF
--- a/e2e/provision/Vagrantfile
+++ b/e2e/provision/Vagrantfile
@@ -43,7 +43,7 @@ Vagrant.configure('2') do |config|
     sh.inline = <<-SHELL
       set -o errexit
       set -o pipefail
-
+      echo "StrictHostKeyChecking no" >> ~/.ssh/config
       cd /vagrant/
       cp nephio.yaml ~/nephio.yaml
       ./gce_install_sandbox.sh | tee ~/gce_install_sandbox.log


### PR DESCRIPTION
Tests done on:
Laptop 1: Windows 11 i7-10750H (16 T) 32GB ram (8VCPU 32GB)
Laptop 2: Windows 10 i5-7200U (4T) 24GB ram (4VCPU 16RAM)

Steps:
- install git
- install virtualbox
- install vagrant
- open git bash
- `git config --global core.autocrlf false`
- `git clone https://github.com/nephio-project/test-infra.git && cd test-infra/e2e/provision`
- `vagrant up`

[Disabling host ssh key check for connecting into the vm](https://docs.ansible.com/ansible/latest/inventory_guide/connection_details.html#managing-host-key-checking), in order to run the installation script without having the machine key.
In the ansible.cfg there is already this parameter (host_key_checking = False) but on windows it would fail:
`fatal: [hostname] => SSH Error: Host key verification failed.
    while connecting to 127.0.0.1:22`
    
Also in order to access the nephio web-ui and gitea web-ui, the vagrant networking will not work on windows for [Hyper-V limitation](https://developer.hashicorp.com/vagrant/docs/providers/hyperv/limitations#limited-networking). Meanwhile for [Virtualbox](https://developer.hashicorp.com/vagrant/docs/providers/virtualbox/networking#virtualbox-nic-type) we can create an internal network  adding this line to Vagrant.configure: 
`config.vm.network "private_network", ip: "192.168.50.4", virtualbox__intnet: true`

But the easiest way is to force the port-forwarding in the common way:
`vagrant ssh -- -L 7007:localhost:7007 -L 3000:172.18.0.200:3000`
