### PR TITLE
Use v3 of the free5gc operator package

### DIFF
--- a/e2e/tests/004-free5gc-operator.yaml
+++ b/e2e/tests/004-free5gc-operator.yaml
@@ -6,7 +6,7 @@ spec:
   upstream:
     repo: free5gc-packages
     package: free5gc-operator
-    revision: v2
+    revision: v3
   targets:
   - objectSelector:
       apiVersion: infra.nephio.org/v1alpha1

--- a/e2e/tests/004.sh
+++ b/e2e/tests/004.sh
@@ -31,6 +31,6 @@ k8s_apply "$kubeconfig" "$TESTDIR/004-free5gc-operator.yaml"
 
 for cluster in "regional" "edge01" "edge02"; do
   cluster_kubeconfig=$(k8s_get_capi_kubeconfig "$kubeconfig" "default" "regional")
-  k8s_wait_exists "$cluster_kubeconfig" 600 "free5gc" "deployment" "free5gc-operator-controller-controller"
-  k8s_wait_ready_replicas "$cluster_kubeconfig" 600 "free5gc" "deployment" "free5gc-operator-controller-controller"
+  k8s_wait_exists "$cluster_kubeconfig" 600 "free5gc" "deployment" "free5gc-operator-controller"
+  k8s_wait_ready_replicas "$cluster_kubeconfig" 600 "free5gc" "deployment" "free5gc-operator-controller"
 done


### PR DESCRIPTION
Update to use the recent operator, and test for that in the deployment.