### PR TITLE
Activate changes in Docker group

### DIFF
--- a/e2e/provision/gce_init.sh
+++ b/e2e/provision/gce_init.sh
@@ -56,6 +56,7 @@ runuser -u $NEPHIO_USER ./gce_install_sandbox.sh
 # Grant Docker permissions to current user
 if ! getent group docker | grep -q "$NEPHIO_USER"; then
     sudo usermod -aG docker "$NEPHIO_USER"
+    newgrp docker
 fi
 
 if [[ "$RUN_E2E" == "true" ]]; then


### PR DESCRIPTION
Adding user in Docker group also requires some activation via restarting the VM or launching newgrp command (cf https://docs.docker.com/engine/install/linux-postinstall/)