### PR TITLE
Updated init script to allow metadata override

### DIFF
--- a/e2e/provision/README.md
+++ b/e2e/provision/README.md
@@ -461,3 +461,20 @@ kubectl apply -f test-infra/e2e/tests/005-regional-free5gc-amf.yaml
 kubectl apply -f test-infra/e2e/tests/005-regional-free5gc-smf.yaml
 kubectl apply -f test-infra/e2e/tests/006-edge-free5gc-upf.yaml
 ```
+# Quick Start for VM running on Openstack
+
+## Step 1: Order or Create a VM using your local VM
+
+Order or create a VM with the following specification:
+- Linux Flavour: Ubuntu-22.04-jammy
+- 16 cores
+- 32 GB memory
+- 200 GB disk size
+- default user is "ubuntu" and "ubuntu" has sudo rights
+
+## Step 2: Kick off the install
+```
+wget -O - https://raw.githubusercontent.com/nephio-project/test-infra/main/e2e/provision/gce_init.sh |  \
+sudo NEPHIO_DEBUG=false   \
+     NEPHIO_USER=ubuntu  \
+     bash

--- a/e2e/provision/README.md
+++ b/e2e/provision/README.md
@@ -470,7 +470,7 @@ Order or create a VM with the following specification:
 - 16 cores
 - 32 GB memory
 - 200 GB disk size
-- default user is "ubuntu" and "ubuntu" has sudo rights
+- default user is "ubuntu" and "ubuntu" needs sudo passwordless permissions
 
 ## Step 2: Kick off the install
 ```

--- a/e2e/provision/gce_init.sh
+++ b/e2e/provision/gce_init.sh
@@ -19,24 +19,22 @@ function get_metadata {
   echo $(curl -sf "http://metadata.google.internal/computeMetadata/v1/instance/attributes/$md" -H "Metadata-Flavor: Google" || echo "$df")
 }
 
-DEBUG=$(get_metadata nephio-setup-debug "false")
+DEBUG=${NEPHIO_DEBUG:-$(get_metadata nephio-setup-debug "false")}
 
 [[ "$DEBUG" != "true" ]] || set -o xtrace
 
-DEPLOYMENT_TYPE=$(get_metadata nephio-setup-type "r1")
-RUN_E2E=$(get_metadata nephio-run-e2e "false")
-REPO=$(get_metadata nephio-test-infra-repo "https://github.com/nephio-project/test-infra.git")
-BRANCH=$(get_metadata nephio-test-infra-branch "main")
-NEPHIO_USER=${USER:-ubuntu}
+DEPLOYMENT_TYPE=${NEPHIO_DEPLOYMENT_TYPE:-$(get_metadata nephio-setup-type "r1")}
+RUN_E2E=${NEPHIO_RUN_E2E:-$(get_metadata nephio-run-e2e "false")}
+REPO=${NEPHIO_REPO:-$(get_metadata nephio-test-infra-repo "https://github.com/nephio-project/test-infra.git")}
+BRANCH=${NEPHIO_BRANCH:-$(get_metadata nephio-test-infra-branch "main")}
+NEPHIO_USER=${NEPHIO_USER:-ubuntu}
 
-echo "$DEBUG, $DEPLOYMENT_TYPE, $RUN_E2E, $REPO, $BRANCH"
+echo "$DEBUG, $DEPLOYMENT_TYPE, $RUN_E2E, $REPO, $BRANCH, $NEPHIO_USER"
 
 apt-get update
 apt-get install -y git
 
-
 cd /home/$NEPHIO_USER
-
 
 runuser -u $NEPHIO_USER git clone "$REPO" test-infra
 if [[ "$BRANCH" != "main" ]]; then
@@ -49,13 +47,17 @@ chown $NEPHIO_USER:$NEPHIO_USER /home/$NEPHIO_USER/.bash_aliases
 sed -e "s/vagrant/$NEPHIO_USER/" < /home/$NEPHIO_USER/test-infra/e2e/provision/nephio.yaml > /home/$NEPHIO_USER/nephio.yaml
 cd ./test-infra/e2e/provision
 export DEBUG DEPLOYMENT_TYPE
-runuser -u $NEPHIO_USER ./gce_install_sandbox.sh
+
+if ! getent group docker > /dev/null; then
+    addgroup docker
+fi
 
 # Grant Docker permissions to current user
 if ! getent group docker | grep -q "$NEPHIO_USER"; then
     sudo usermod -aG docker "$NEPHIO_USER"
-    newgrp docker
 fi
+
+runuser -u $NEPHIO_USER ./gce_install_sandbox.sh
 
 if [[ "$RUN_E2E" == "true" ]]; then
   runuser -u $NEPHIO_USER ../e2e.sh

--- a/e2e/provision/gce_init.sh
+++ b/e2e/provision/gce_init.sh
@@ -47,17 +47,12 @@ chown $NEPHIO_USER:$NEPHIO_USER /home/$NEPHIO_USER/.bash_aliases
 sed -e "s/vagrant/$NEPHIO_USER/" < /home/$NEPHIO_USER/test-infra/e2e/provision/nephio.yaml > /home/$NEPHIO_USER/nephio.yaml
 cd ./test-infra/e2e/provision
 export DEBUG DEPLOYMENT_TYPE
-
-if ! getent group docker > /dev/null; then
-    addgroup docker
-fi
+runuser -u $NEPHIO_USER ./gce_install_sandbox.sh
 
 # Grant Docker permissions to current user
 if ! getent group docker | grep -q "$NEPHIO_USER"; then
     sudo usermod -aG docker "$NEPHIO_USER"
 fi
-
-runuser -u $NEPHIO_USER ./gce_install_sandbox.sh
 
 if [[ "$RUN_E2E" == "true" ]]; then
   runuser -u $NEPHIO_USER ../e2e.sh

--- a/e2e/provision/gce_install_sandbox.sh
+++ b/e2e/provision/gce_install_sandbox.sh
@@ -22,8 +22,7 @@ function deploy_kpt_pkg {
   local temp=$(mktemp -d -t kpt-XXXX)
   local localpkg="$temp/$name"
   kpt pkg get --for-deployment "https://github.com/nephio-project/nephio-example-packages.git/$pkg" "$localpkg"
-  # sudo because docker
-  sudo kpt fn render "$localpkg"
+  kpt fn render "$localpkg"
   kpt live init "$localpkg"
   kubectl --kubeconfig "$HOME/.kube/config" api-resources
   kpt pkg tree "$localpkg"

--- a/e2e/provision/gce_install_sandbox.sh
+++ b/e2e/provision/gce_install_sandbox.sh
@@ -22,7 +22,8 @@ function deploy_kpt_pkg {
   local temp=$(mktemp -d -t kpt-XXXX)
   local localpkg="$temp/$name"
   kpt pkg get --for-deployment "https://github.com/nephio-project/nephio-example-packages.git/$pkg" "$localpkg"
-  kpt fn render "$localpkg"
+  # sudo because docker
+  sudo kpt fn render "$localpkg"
   kpt live init "$localpkg"
   kubectl --kubeconfig "$HOME/.kube/config" api-resources
   kpt pkg tree "$localpkg"

--- a/e2e/provision/hacks/resolve_secrets.sh
+++ b/e2e/provision/hacks/resolve_secrets.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+set -o pipefail
+set -o errexit
+set -o nounset
+
+function destroy_kpt_pkg {
+  local temp_dir=$1
+  local name=$2
+
+  echo "destroying $name kpt package in $temp_dir . . ."
+  pushd "$temp_dir" > /dev/null
+  kpt live --kubeconfig "$HOME/.kube/config" destroy "$temp_dir/$name"
+  popd > /dev/null
+  echo "destroyed $name kpt package in $temp_dir"
+}
+
+function apply_kpt_pkg {
+  local temp_dir=$1
+  local name=$2
+
+  echo "applying $name kpt package in $temp_dir . . ."
+  pushd "$temp_dir" > /dev/null
+  kpt live --kubeconfig "$HOME/.kube/config" apply "$temp_dir/$name"
+  popd > /dev/null
+  echo "applied $name kpt package in $temp_dir"
+}
+
+kpt_package_count=$(find /tmp -mindepth 1 -maxdepth 1 -type d -name 'kpt*' | wc -l)
+
+if (( kpt_package_count != 3 ))
+then
+  echo "there must be three and only three kpt temporary directories in /tmp"
+  exit 1
+fi
+
+mgmt_temp_dir=$(find /tmp/kpt* | grep 'mgmt\/token-configsync.yaml$' | sed 's/\/mgmt\/token-configsync.yaml$//')
+mgmt_rootsync_temp_dir=$(find /tmp/kpt* | grep 'rootsync.yaml$' | sed 's/\/mgmt\/rootsync.yaml$//')
+mgmt_staging_temp_dir=$(find /tmp/kpt* | grep 'mgmt-staging$' | sed 's/\/mgmt-staging$//')
+
+echo "found mgmt kpt package in $mgmt_temp_dir"
+echo "found mgmt rootsync kpt package in $mgmt_rootsync_temp_dir"
+echo "found mgmt-staging kpt package in $mgmt_staging_temp_dir"
+
+destroy_kpt_pkg "$mgmt_staging_temp_dir"  "mgmt-staging"
+destroy_kpt_pkg "$mgmt_rootsync_temp_dir" "mgmt"
+destroy_kpt_pkg "$mgmt_temp_dir"          "mgmt"
+
+echo "waiting for pods to stop crashing . . ."
+pods_crashing=true
+while [ "$pods_crashing" = true ]
+do
+  sleep 10
+  if ! kubectl --kubeconfig "$HOME/.kube/config" get pods -A | grep -q CrashLoopBackOff
+  then
+    pods_crashing=false
+  fi
+done 
+echo "pods have stopped crashing"
+
+apply_kpt_pkg   "$mgmt_temp_dir"          "mgmt"
+apply_kpt_pkg   "$mgmt_rootsync_temp_dir" "mgmt"
+apply_kpt_pkg   "$mgmt_staging_temp_dir"  "mgmt-staging"

--- a/e2e/provision/hacks/resolve_secrets.sh
+++ b/e2e/provision/hacks/resolve_secrets.sh
@@ -54,17 +54,9 @@ destroy_kpt_pkg "$mgmt_staging_temp_dir"  "mgmt-staging"
 destroy_kpt_pkg "$mgmt_rootsync_temp_dir" "mgmt"
 destroy_kpt_pkg "$mgmt_temp_dir"          "mgmt"
 
-echo "waiting for pods to stop crashing . . ."
-pods_crashing=true
-while [ "$pods_crashing" = true ]
-do
-  sleep 10
-  if ! kubectl --kubeconfig "$HOME/.kube/config" get pods -A | grep -q CrashLoopBackOff
-  then
-    pods_crashing=false
-  fi
-done 
-echo "pods have stopped crashing"
+echo "waiting 60 seconds for package deletions to propogate . . ."
+sleep 60
+echo "continuing . . ."
 
 apply_kpt_pkg   "$mgmt_temp_dir"          "mgmt"
 apply_kpt_pkg   "$mgmt_rootsync_temp_dir" "mgmt"


### PR DESCRIPTION
This PR:

- Allows the initialization variables to be overridden on invocation without using the get metadata, for example by using
   cat gce_init.sh | sudo NEPHIO_DEBUG=true NEPHIO_RUN_E2E=false bash
- Creates the docker use before management cluster invocation to allow the kpt fn apply commands in the
   gce_install_sandbox.sh script to run on the nephio user.