### PR TITLE
Enable GitHub Actions for Integration tests

### DIFF
--- a/e2e/provision/.github/actions/molecule-test/action.yml
+++ b/e2e/provision/.github/actions/molecule-test/action.yml
@@ -1,0 +1,41 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+name: Molecule execution
+inputs:
+  tox-env:
+    description: 'Python TOX environment'
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-python@v4.3.1
+      with:
+        python-version: '3.x'
+    - uses: syphar/restore-virtualenv@v1.2
+      id: cache-tox-molecule
+      with:
+        requirement_files: e2e/provision/test-requirements.txt
+        custom_virtualenv_dir: .tox/molecule
+    - name: Install Tox tool
+      shell: bash
+      run: brew install tox
+    - name: Install vagrant tool
+      shell: bash
+      run: brew install vagrant
+    - uses: ./.github/actions/vagrant-setup
+    - name: Run molecule tests
+      shell: bash
+      env:
+        VAGRANT_DISABLE_VBOXSYMLINKCREATE: 1
+        VAGRANT_HOME: /tmp
+        TOXENV: ${{ inputs.tox-env }}
+      run: tox
+      working-directory: e2e/provision/

--- a/e2e/provision/.github/actions/vagrant-setup/action.yml
+++ b/e2e/provision/.github/actions/vagrant-setup/action.yml
@@ -1,0 +1,38 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+name: Vagrant setup
+
+inputs:
+  distro:
+    description: Linux distribution
+    default: ubuntu_focal
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cache Vagrant boxes
+      uses: actions/cache@v3.0.10
+      with:
+        path: ~/.vagrant.d/boxes
+        key: ${{ runner.os }}-vagrant-${{ inputs.distro }}-${{ hashFiles('distros_supported.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-vagrant-${{ inputs.distro }}-
+          ${{ runner.os }}-vagrant-${{ hashFiles('distros_supported.yml') }}
+    - name: Apply workaround for VBoxHeadless issue on macOS (https://www.virtualbox.org/ticket/20636)
+      shell: bash
+      run: |
+        if [[ "$(VBoxManage --version)" == "6.1.28r147628" ]]; then
+            find . -type f -iname "Vagrantfile" -exec sed -i '.bak' 's|v.gui = .*|v.gui = true|g' {} \;
+            find . -type f -name "*.bak" -delete
+        fi
+    - name: Install vagrant tool
+      shell: bash
+      run: brew install vagrant

--- a/e2e/provision/.github/dependabot.yml
+++ b/e2e/provision/.github/dependabot.yml
@@ -8,15 +8,9 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 ##############################################################################
 
-host_min_vcpu: 8  # minimum required vCPUs before install
-host_min_cpu_ram: 16  # minimum required CPU RAM before install; value in GB
-host_min_root_disk_space: 50  # minimum required disk space before install; value in GB
-
-container_engine: docker
-kubernetes_version: v1.26.3
-
-gitea_postgres_password: c2VjcmV0  # echo -n "secret" | base64
-gitea_db_password: c2VjcmV0
-
-gitea_username: nephio
-gitea_password: secret
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/e2e/provision/.github/workflows/on-demand_molecule.yml
+++ b/e2e/provision/.github/workflows/on-demand_molecule.yml
@@ -1,0 +1,89 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+name: Check All Molecule tests
+# yamllint disable-line rule:truthy
+on:
+  push:
+    paths:
+      - e2e/provision/galaxy-requirements.yml
+      - e2e/provision/test-requirements.txt
+      - e2e/provision/playbooks/roles/**
+  pull_request_review:
+    types:
+      - submitted
+
+jobs:
+  bootstrap:
+    name: Pull python dependencies
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3.5.3
+      - uses: actions/setup-python@v4.6.1
+        with:
+          python-version: '3.x'
+      - uses: syphar/restore-virtualenv@v1.3
+        id: cache-tox-molecule
+        with:
+          requirement_files: e2e/provision/test-requirements.txt
+          custom_virtualenv_dir: .tox/molecule
+      - uses: syphar/restore-pip-download-cache@v1.2
+        if: steps.cache-tox-molecule.outputs.cache-hit != 'true'
+        with:
+          requirement_files: e2e/provision/test-requirements.txt
+      - run: pip install -r e2e/provision/test-requirements.txt
+        if: steps.cache-tox-molecule.outputs.cache-hit != 'true'
+  changes:
+    runs-on: ubuntu-latest
+    if: >-
+      (
+        github.event_name == 'pull_request_review' &&
+        github.event.review.state == 'approved'
+      ) ||
+      github.event_name != 'pull_request_review'
+    needs: bootstrap
+    outputs:
+      environments: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: actions/checkout@v3.5.3
+      - uses: dorny/paths-filter@v2.11.1
+        if: ${{ !env.ACT }}
+        id: filter
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            reqs: &reqs
+              - e2e/provision/galaxy-requirements.yml
+              - e2e/provision/test-requirements.txt
+              - 'e2e/provision/playbooks/library/**'
+            bootstrap:
+              - *reqs
+              - 'e2e/provision/playbooks/roles/bootstrap/**'
+            kpt:
+              - *reqs
+              - 'e2e/provision/playbooks/roles/kpt/**'
+            install:
+              - *reqs
+              - 'e2e/provision/playbooks/roles/install/**'
+  check-molecule:
+    name: Check Ansible role with Molecule tests
+    needs: changes
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: ${{ fromJSON(needs.changes.outputs.environments) }}
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3.5.3
+        if: matrix.environment != 'reqs'
+      - uses: ./.github/actions/molecule-test
+        if: matrix.environment != 'reqs'
+        with:
+          tox-env: ${{ matrix.environment }}


### PR DESCRIPTION
This is an initial proposal for enabling molecule tests execution (integration tests) through GitHub actions. It's also created for validating that prow and GH actions can coexist.