### PR TITLE
Use init.sh bash script as main starting point

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -30,7 +30,7 @@ presubmits:
             - "-c"
             - |
               set -eE; cd e2e/terraform; trap 'terraform destroy -auto-approve' EXIT;
-              terraform init && timeout 45m terraform apply -auto-approve
+              terraform init && timeout 1h terraform apply -auto-approve
           volumeMounts:
             - name: satoken
               mountPath: "/etc/satoken"
@@ -226,7 +226,7 @@ periodics:
             - "-c"
             - |
               set -eE; cd e2e/terraform; trap 'terraform destroy -auto-approve' EXIT;
-              terraform init && timeout 45m terraform apply -auto-approve
+              terraform init && timeout 1h terraform apply -auto-approve
           volumeMounts:
             - name: satoken
               mountPath: "/etc/satoken"

--- a/e2e/provision/Vagrantfile
+++ b/e2e/provision/Vagrantfile
@@ -18,7 +18,8 @@ Vagrant.configure('2') do |config|
 
   config.vm.box = 'generic/ubuntu2004'
   config.vm.box_check_update = false
-  config.vm.synced_folder './', '/vagrant'
+  vagrant_root = File.dirname(__FILE__)
+  config.vm.synced_folder "#{vagrant_root}/../../", '/opt/test-infra'
 
   config.vm.network 'forwarded_port', guest: 7007, guest_ip: '127.0.0.1', host: 7007
   config.vm.network 'forwarded_port', guest: 3000, guest_ip: '172.18.0.200', host: 3000
@@ -29,24 +30,24 @@ Vagrant.configure('2') do |config|
         sudo sed -i "s/addresses: .*/addresses: [1.1.1.1, 8.8.8.8, 8.8.4.4]/g" /etc/netplan/01-netcfg.yaml
         sudo netplan apply
     fi
-    # Create .bash_aliases
-    echo 'cd /vagrant/' >> /home/vagrant/.bash_aliases
-    chown vagrant:vagrant /home/vagrant/.bash_aliases
   SHELL
 
   # Provision test bed
-  config.vm.provision 'shell', privileged: false do |sh|
+  config.vm.provision 'shell', privileged: true do |sh|
     sh.env = {
-      DEBUG: ENV.fetch('DEBUG', true),
-      DEPLOYMENT_TYPE: ENV.fetch('DEPLOYMENT_TYPE', 'r1')
+      NEPHIO_DEBUG: ENV.fetch('DEBUG', true),
+      NEPHIO_DEPLOYMENT_TYPE: ENV.fetch('DEPLOYMENT_TYPE', 'r1'),
+      NEPHIO_RUN_E2E: ENV.fetch('RUN_E2E', false),
+      NEPHIO_USER: 'vagrant',
+      NEPHIO_REPO_DIR: '/opt/test-infra',
+      E2EDIR: '/opt/test-infra/e2e'
     }
     sh.inline = <<-SHELL
       set -o errexit
       set -o pipefail
-      echo "StrictHostKeyChecking no" >> ~/.ssh/config
-      cd /vagrant/
-      cp nephio.yaml ~/nephio.yaml
-      ./install_sandbox.sh | tee ~/install_sandbox.log
+
+      cd /opt/test-infra/e2e/provision/
+      ./init.sh | tee ~/init.log
     SHELL
   end
 
@@ -69,7 +70,7 @@ Vagrant.configure('2') do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    override.vm.synced_folder './', '/vagrant', type: 'virtiofs'
+    override.vm.synced_folder "#{vagrant_root}/../../", '/opt/test-infra', type: 'virtiofs'
     v.memorybacking :access, mode: 'shared'
     v.random_hostname = true
     v.management_network_address = '10.0.2.0/24'

--- a/e2e/provision/install_sandbox.sh
+++ b/e2e/provision/install_sandbox.sh
@@ -78,11 +78,18 @@ if [ "${DEPLOYMENT_TYPE:-r1}" == "one-summit" ]; then
     popd >/dev/null
 else
     trap get_status ERR
+
+    mkdir -p ~/.ssh/
+    touch ~/.ssh/config
+    if ! grep -q "StrictHostKeyChecking no" ~/.ssh/config; then
+        echo "StrictHostKeyChecking no" >>~/.ssh/config
+    fi
+    chmod 600 ~/.ssh/config
     # Management cluster creation
     if [[ ${DEBUG:-false} != "true" ]]; then
-        ansible-playbook -i ~/nephio.yaml playbooks/cluster.yml
+        ansible-playbook -i ./nephio.yaml playbooks/cluster.yml
     else
-        ansible-playbook -vvv -i ~/nephio.yaml playbooks/cluster.yml
+        ansible-playbook -vvv -i ./nephio.yaml playbooks/cluster.yml
     fi
 
     # Put this in the ubuntu dir and make it accessible to world

--- a/e2e/terraform/main.tf
+++ b/e2e/terraform/main.tf
@@ -60,8 +60,8 @@ resource "google_compute_instance" "e2e_instances" {
     }
   }
   provisioner "file" {
-    source      = "../provision"
-    destination = "/home/ubuntu/provision"
+    source      = "../../../test-infra"
+    destination = "/home/ubuntu/test-infra"
     connection {
       host        = self.network_interface[0].access_config[0].nat_ip
       type        = "ssh"
@@ -90,9 +90,9 @@ resource "google_compute_instance" "e2e_instances" {
       agent       = false
     }
     inline = [
-      "cd provision/",
-      "chmod +x install_sandbox.sh",
-      "DEBUG=true ./install_sandbox.sh"
+      "cd /home/ubuntu/test-infra/e2e/provision/",
+      "chmod +x init.sh",
+      "sudo -E NEPHIO_REPO_DIR=/home/ubuntu/test-infra NEPHIO_DEBUG=true NEPHIO_RUN_E2E=true ./init.sh"
     ]
   }
 }

--- a/e2e/terraform/variables.tf
+++ b/e2e/terraform/variables.tf
@@ -11,7 +11,7 @@ variable "zone" {
 }
 
 variable "instance" {
-  default = "e2-standard-8"
+  default = "e2-standard-16"
 }
 
 variable "credentials" {


### PR DESCRIPTION
This PR centralizes the`init.sh` script usage. Terraform (e2e CI process) and Vagrant (local) provisioning process will be using the same script. This will provide the same developer experience for the distinct provisioning process.