### PR TITLE
Import the bash gtp5g installation into Ansible role

### DIFF
--- a/e2e/provision/install_sandbox.sh
+++ b/e2e/provision/install_sandbox.sh
@@ -63,29 +63,6 @@ rm -f ~/.ssh/id_rsa*
 echo -e "\n\n\n" | ssh-keygen -t rsa -N ""
 cat "$HOME/.ssh/id_rsa.pub" >>"$HOME/.ssh/authorized_keys"
 
-KVER=$(uname -r)
-
-if ! lsmod | grep -q gtp5g; then
-    [[ -d "$HOME/gtp5g" ]] || git clone --depth 1 -b v0.6.8 https://github.com/free5gc/gtp5g.git "$HOME/gtp5g"
-
-    pushd "$HOME/gtp5g" >/dev/null
-    GCC=gcc
-    if [[ $(uname -v) == *22.04.*-Ubuntu* ]]; then
-        GCC=gcc-12
-    fi
-    if ! command -v $GCC >/dev/null; then
-        sudo apt-get -y install $GCC
-    fi
-    if [[ ! -d "/lib/modules/$KVER/build" ]]; then
-        sudo apt-get -y install "linux-headers-$KVER"
-    fi
-    make
-    sudo make install
-    sudo modprobe gtp5g
-    sudo dmesg | tail -n 4
-    popd >/dev/null
-fi
-
 if [ "${DEPLOYMENT_TYPE:-r1}" == "one-summit" ]; then
     [[ -d "$HOME/workshop" ]] || git clone --depth 1 https://github.com/nephio-project/one-summit-22-workshop.git "$HOME/workshop"
     mkdir -p "$HOME/workshop/nephio-ansible-install/inventory"

--- a/e2e/provision/playbooks/roles/bootstrap/defaults/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/defaults/main.yml
@@ -20,3 +20,7 @@ gitea_db_password: c2VjcmV0
 
 gitea_username: nephio
 gitea_password: secret
+
+gtp5g_dest: /opt/gtp5g
+gtp5g_version: v0.6.8
+gtp5g_tarball_url: "https://github.com/free5gc/gtp5g/archive/refs/tags/{{ gtp5g_version }}.tar.gz"

--- a/e2e/provision/playbooks/roles/bootstrap/molecule/default/tests/test_default.py
+++ b/e2e/provision/playbooks/roles/bootstrap/molecule/default/tests/test_default.py
@@ -14,6 +14,10 @@
 #
 
 
+def test_gtp5g_load(host):
+    cmd = host.run("modinfo gtp5g")
+    assert cmd.succeeded
+
 def test_kind_creation(host):
     kind = host.docker("kind-control-plane")
 

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/load-gtp5g-module.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/load-gtp5g-module.yml
@@ -1,0 +1,72 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+- name: Load OS specific variables
+  ansible.builtin.include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version|lower|replace('/', '_') }}.yml"
+        - "{{ ansible_distribution|lower }}.yml"
+        - "{{ ansible_os_family|lower }}.yml"
+      skip: true
+
+- name: Install compilation packages
+  become: true
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ build_pkgs }}"
+
+- name: Install Debian kernel development tools
+  become: true
+  ansible.builtin.package:
+    name: "linux-headers-{{ ansible_kernel }}"
+    state: present
+  when: ansible_os_family == 'Debian'
+
+- name: Get gtp5g module information
+  ansible.builtin.command: modinfo gtp5g
+  register: bootstrap_modinfo_gtp5g
+  ignore_errors: true
+  changed_when: false
+
+- name: Print gtp5g module information
+  ansible.builtin.debug:
+    var: bootstrap_modinfo_gtp5g
+
+- name: Create gtp5g destination folder
+  become: true
+  ansible.builtin.file:
+    mode: '0755'
+    state: directory
+    path: "{{ gtp5g_dest }}"
+    owner: "{{ ansible_user_uid }}"
+    group: "{{ ansible_user_gid }}"
+
+- name: Extract gtp5g driver source code
+  ansible.builtin.unarchive:
+    mode: '0755'
+    src: "{{ gtp5g_tarball_url }}"
+    dest: "{{ gtp5g_dest }}"
+    remote_src: true
+    owner: "{{ ansible_user_uid }}"
+    extra_opts: [--strip-components=1, --overwrite]
+
+- name: Configure gtp5g module
+  community.general.make:
+    chdir: "{{ gtp5g_dest }}"
+  when: '"ERROR: Module gtp5g not found." in bootstrap_modinfo_gtp5g.stderr'
+
+- name: Install gtp5g module
+  become: true
+  community.general.make:
+    chdir: "{{ gtp5g_dest }}"
+    target: install
+  when: '"ERROR: Module gtp5g not found." in bootstrap_modinfo_gtp5g.stderr'

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
@@ -11,6 +11,9 @@
 - name: Check Host requirements
   ansible.builtin.include_tasks: prechecks.yml
 
+- name: Load gtp5g kernel module
+  ansible.builtin.include_tasks: load-gtp5g-module.yml
+
 - name: Set Kernel Parameters
   ansible.builtin.include_tasks: system-setup.yml
 

--- a/e2e/provision/playbooks/roles/bootstrap/vars/ubuntu-20.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/vars/ubuntu-20.yml
@@ -1,0 +1,13 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+build_pkgs:
+  - make
+  - gcc-10

--- a/e2e/provision/playbooks/roles/bootstrap/vars/ubuntu-22.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/vars/ubuntu-22.yml
@@ -1,0 +1,13 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+build_pkgs:
+  - make
+  - gcc-12


### PR DESCRIPTION
There are some [random failures](http://prow.nephio.io/view/gs/prow-nephio-sig-release/pr-logs/pull/nephio-project_test-infra/93/e2e/1669099496241369088#1:build-log.txt%3A6717) on the CI to detect the right package for gcc. This change tries to cover all the possibilities.