### PR TITLE
add CLA plugin

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -16,6 +16,7 @@ plugins:
     - retitle
     - override
     - lifecycle
+    - cla
   nephio-project/test-infra:
     plugins:
     - config-updater


### PR DESCRIPTION
This allows to re-check cla status separate from GitHub's own mechanisms