### PR TITLE
Import kubeconfig creation into Ansible Role

### DIFF
--- a/e2e/provision/install_sandbox.sh
+++ b/e2e/provision/install_sandbox.sh
@@ -68,12 +68,6 @@ else
     else
         ansible-playbook -vvv -i ./nephio.yaml playbooks/cluster.yml
     fi
-
-    # Put this in the ubuntu dir and make it accessible to world
-    mkdir "$HOME/.kube" && chmod 755 "$HOME/.kube"
-    sudo cp /root/.kube/config "$HOME/.kube"
-    sudo chown $USER:$USER "$HOME/.kube/config"
-    chmod 644 "$HOME/.kube/config"
 fi
 
 echo "Done installing Nephio Sandbox Environment"

--- a/e2e/provision/playbooks/roles/bootstrap/README.md
+++ b/e2e/provision/playbooks/roles/bootstrap/README.md
@@ -63,8 +63,10 @@ flowchart TD
     Q --> R(Get k8s clusters)
     R --> S{not 'kind' in bootstrap_kind_get_cluster.stdout?}
     S -- true --> T(Create management cluster)
+    T --> U(Create .kube directory)
     S -- false --> U
-    T --> U(Create gitea namespace)
-    U --> V(Create gitea postgresql user password)
-    V --> W(Deploy base packages)
+    U --> V(Copy root kubeconfig file)
+    V --> W(Create gitea namespace)
+    W --> Y(Create gitea postgresql user password)
+    Y --> Z(Deploy base packages)
 ```

--- a/e2e/provision/playbooks/roles/bootstrap/molecule/default/molecule.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/molecule/default/molecule.yml
@@ -40,5 +40,3 @@ provisioner:
         host_min_cpu_ram: 1
 verifier:
   name: testinfra
-  options:
-    sudo: true

--- a/e2e/provision/playbooks/roles/bootstrap/molecule/default/tests/test_default.py
+++ b/e2e/provision/playbooks/roles/bootstrap/molecule/default/tests/test_default.py
@@ -33,21 +33,22 @@ def test_kernel_parameters_validation(host):
 
 
 def test_kind_cluster_creation(host):
-    kind = host.docker("kind-control-plane")
+    with host.sudo():
+        kind = host.docker("kind-control-plane")
+        assert kind.is_running
 
-    assert kind.is_running
-    destinations = host.check_output(
-        "docker inspect \
+        destinations = host.check_output(
+            "docker inspect \
 --format '{{range .Mounts }}{{.Destination}}{{\"\\n\"}}{{end}}' \
 kind-control-plane"
-    )
-    assert "/var/run/docker.sock" in destinations
-    sources = host.check_output(
-        "docker inspect \
+        )
+        assert "/var/run/docker.sock" in destinations
+        sources = host.check_output(
+            "docker inspect \
 --format '{{range .Mounts }}{{.Source}}{{\"\\n\"}}{{end}}' \
 kind-control-plane"
-    )
-    assert "/var/run/docker.sock" in sources
+        )
+        assert "/var/run/docker.sock" in sources
 
 
 def test_gitea_namespace_creation(host):

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
@@ -33,7 +33,7 @@
 
 - name: Create management cluster
   become: true
-  ansible.builtin.command: kind create cluster --config=-
+  ansible.builtin.command: kind create cluster --kubeconfig /tmp/kubeconfig --config=-
   args:
     stdin: |
       kind: Cluster
@@ -47,8 +47,23 @@
   when: not 'kind' in bootstrap_kind_get_cluster.stdout
   changed_when: true
 
-- name: Create gitea namespace
+- name: Create .kube directory
+  ansible.builtin.file:
+    path: "{{ ansible_user_dir }}/.kube"
+    state: directory
+    mode: '0755'
+
+- name: Copy root kubeconfig file
   become: true
+  ansible.builtin.copy:
+    remote_src: true
+    src: /tmp/kubeconfig
+    dest: "{{ ansible_user_dir }}/.kube/config"
+    owner: "{{ ansible_user_uid }}"
+    group: "{{ ansible_user_gid }}"
+    mode: '0644'
+
+- name: Create gitea namespace
   kubernetes.core.k8s:
     state: present
     definition:
@@ -58,7 +73,6 @@
         name: gitea
 
 - name: Create gitea postgresql user password
-  become: true
   kubernetes.core.k8s:
     state: present
     definition:
@@ -76,7 +90,6 @@
         password: "{{ gitea_db_password }}"
 
 - name: Create gitea user password
-  become: true
   kubernetes.core.k8s:
     state: present
     definition:

--- a/e2e/provision/playbooks/roles/install/molecule/default/molecule.yml
+++ b/e2e/provision/playbooks/roles/install/molecule/default/molecule.yml
@@ -33,5 +33,3 @@ provisioner:
     ANSIBLE_LIBRARY: ${MOLECULE_PROJECT_DIRECTORY}/../../../playbooks/library
 verifier:
   name: testinfra
-  options:
-    sudo: true

--- a/e2e/provision/playbooks/roles/install/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/install/tasks/main.yml
@@ -24,7 +24,6 @@
     context: kind-kind
 
 - name: Create gitea user password in nephio-system namespace
-  become: true
   kubernetes.core.k8s:
     context: kind-kind
     state: present

--- a/e2e/provision/playbooks/roles/kpt/molecule/default/molecule.yml
+++ b/e2e/provision/playbooks/roles/kpt/molecule/default/molecule.yml
@@ -39,5 +39,3 @@ provisioner:
           - default
 verifier:
   name: testinfra
-  options:
-    sudo: true

--- a/e2e/provision/playbooks/roles/kpt/molecule/default/prepare.yml
+++ b/e2e/provision/playbooks/roles/kpt/molecule/default/prepare.yml
@@ -46,5 +46,19 @@
       failed_when: (kind_get_cluster.rc not in [0, 1])
     - name: Create k8s cluster
       become: true
-      ansible.builtin.command: kind create cluster --image kindest/node:v1.27.1
+      ansible.builtin.command: kind create cluster --image kindest/node:v1.27.1 --kubeconfig=/tmp/kubeconfig
       when: not 'kind' in kind_get_cluster.stdout
+    - name: Create .kube directory
+      ansible.builtin.file:
+        path: "{{ ansible_user_dir }}/.kube"
+        state: directory
+        mode: '0755'
+    - name: Copy root kubeconfig file
+      become: true
+      ansible.builtin.copy:
+        remote_src: true
+        src: /tmp/kubeconfig
+        dest: "{{ ansible_user_dir }}/.kube/config"
+        owner: "{{ ansible_user_uid }}"
+        group: "{{ ansible_user_gid }}"
+        mode: '0644'

--- a/e2e/provision/playbooks/roles/kpt/molecule/default/tests/test_default.py
+++ b/e2e/provision/playbooks/roles/kpt/molecule/default/tests/test_default.py
@@ -16,16 +16,16 @@
 
 def test_deployments(host):
     got = host.check_output(
-        "sudo kubectl get deploy --no-headers -o custom-columns=':metadata.name'"
+        "kubectl get deploy --no-headers -o custom-columns=':metadata.name'"
     )
     assert "my-nginx" == got
-    cmd = host.run("sudo kubectl rollout status deployment/my-nginx")
+    cmd = host.run("kubectl rollout status deployment/my-nginx")
     assert cmd.succeeded
     assert cmd.rc == 0
 
 
 def test_services(host):
     got = host.check_output(
-        "sudo kubectl get service --no-headers -o custom-columns=':metadata.name'"
+        "kubectl get service --no-headers -o custom-columns=':metadata.name'"
     )
     assert "my-nginx-svc" in got

--- a/e2e/provision/playbooks/roles/kpt/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/kpt/tasks/main.yml
@@ -43,6 +43,14 @@
     pkg_path: "{{ workdir }}"
     command: fn-render
 
+- name: Recursively restore ownership of a directory package
+  ansible.builtin.file:
+    path: "{{ workdir }}"
+    state: directory
+    owner: "{{ ansible_user_uid }}"
+    group: "{{ ansible_user_gid }}"
+    recurse: true
+
 - name: Get package differences between local and upstream
   kpt:
     pkg_path: "{{ workdir }}"
@@ -60,7 +68,6 @@
   register: kpt_resourcegroup
 
 - name: Init package
-  become: true
   kpt:
     pkg_path: "{{ workdir }}"
     version: "{{ version }}"
@@ -74,7 +81,6 @@
     var: kpt_live_init
 
 - name: Apply package
-  become: true
   kpt:
     pkg_path: "{{ workdir }}"
     version: "{{ version }}"

--- a/e2e/provision/playbooks/roles/kpt/tasks/wait_deployments.yml
+++ b/e2e/provision/playbooks/roles/kpt/tasks/wait_deployments.yml
@@ -9,7 +9,6 @@
 ##############################################################################
 
 - name: Get deployment resources
-  become: true
   kubernetes.core.k8s_info:
     context: "{{ context }}"
     api_version: v1
@@ -22,7 +21,6 @@
     var: deployment_list.resources
 
 - name: Wait for deployments
-  become: true
   kubernetes.core.k8s:
     context: "{{ context }}"
     definition:


### PR DESCRIPTION
The Nephio management cluster is created with `root` user during the execution of the `bootstrap` Ansible role. As a consequence, many tasks have to be executed with elevated permissions. An initial workaround was to fix it after the Ansible execution. This change removes that workaround and includes those instructions as part of the `bootstrap` process.