### PR TITLE
Create repository settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+*.sh eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary


### PR DESCRIPTION
[Windows users](https://github.com/nephio-project/docs/pull/20) have to configure `core.autocrlf` to avoid any change on the repo. The `.gitattributes` file offers the alternative to configure the repository to provide a consistent behavior. 

