### PR TITLE
Import kpt bash instructions in Ansible

### DIFF
--- a/e2e/provision/playbooks/cluster.yml
+++ b/e2e/provision/playbooks/cluster.yml
@@ -40,6 +40,21 @@
     - bootstrap
     - install
   tasks:
+    - name: Deploy repositories
+      ansible.builtin.include_role:
+        name: kpt
+      loop:
+        - {pkg: repository, version: repository/v3, namespaces: [], dest: /tmp/repository/mgmt}
+        - {pkg: rootsync, version: rootsync/v3, namespaces: [], dest: /tmp/rootsync/mgmt}
+        - {pkg: repository, version: repository/v3, namespaces: [], dest: /tmp/repository/mgmt-staging}
+      vars:
+        repo_uri: https://github.com/nephio-project/nephio-example-packages
+        local_dest_directory: "{{ item.dest }}"
+        pkg: "{{ item.pkg }}"
+        version: "{{ item.version }}"
+        namespaces: "{{ item.namespaces }}"
+        for_deployment: true
+        context: kind-kind
     - name: Install container lab tool
       become: true
       ansible.builtin.apt:

--- a/e2e/provision/playbooks/library/kpt.py
+++ b/e2e/provision/playbooks/library/kpt.py
@@ -312,9 +312,9 @@ class KptClient:
         result = dict(changed=False, rc=0, cmd=" ".join(cmd))
 
         dest = (
-            (local_dest_directory if local_dest_directory else ".")
-            + "/"
-            + pkg_path.split("/")[-1]
+            local_dest_directory
+            if local_dest_directory
+            else "./" + pkg_path.split("/")[-1]
         )
         if not os.path.exists(dest):
             self._run(cmd)
@@ -356,7 +356,7 @@ class KptClient:
             cmd.extend(["--output", output])
         if results_dir:
             cmd.extend(["--results-dir", results_dir])
-        self._run(cmd)
+        self._run(cmd, False)
 
     # Initialize a package with the information needed for inventory tracking.
     def live_init(
@@ -424,7 +424,7 @@ class KptClient:
             cmd.extend(["--show-status-events", show_status_events])
         if context:
             cmd.extend(["--context", context])
-        self._run(cmd)
+        self._run(cmd, False)
 
 
 def main():

--- a/e2e/provision/playbooks/library/kpt.py
+++ b/e2e/provision/playbooks/library/kpt.py
@@ -63,6 +63,12 @@ options:
           - resource-merge
           - fast-forward
           - force-delete-replace
+    for_deployment:
+        description:
+           - (Experimental) indicates if the fetched package is a deployable
+             instance that will be deployed to a cluster.
+        required: false
+        type: bool
     directory:
         description:
           - Directory of the kpt package.
@@ -290,7 +296,14 @@ class KptClient:
 
     # Fetch a package from a git repo.
     def pkg_get(
-        self, repo_uri, pkg_path, local_dest_directory, version, strategy, **kargs
+        self,
+        repo_uri,
+        pkg_path,
+        local_dest_directory,
+        version,
+        strategy,
+        for_deployment,
+        **kargs
     ):
         cmd = [self._kpt_cmd_path, "pkg", "get"]
         cmd.append(
@@ -302,6 +315,8 @@ class KptClient:
         )
         if local_dest_directory:
             cmd.append(local_dest_directory)
+        if for_deployment:
+            cmd.append("--for-deployment")
         if strategy and strategy in [
             "resource-merge",
             "fast-forward",
@@ -434,6 +449,7 @@ def main():
         version=dict(type="str", required=False),
         local_dest_directory=dict(type="str", required=False),
         strategy=dict(type="str", required=False),
+        for_deployment=dict(type="bool", required=False),
         directory=dict(type="str", required=False),
         diff_type=dict(type="bool", required=False),
         diff_tool=dict(type="str", required=False),

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
@@ -101,7 +101,6 @@
     - {pkg: resource-backend, version: resource-backend/v2, namespaces: [backend-system]}
   vars:
     repo_uri: https://github.com/nephio-project/nephio-example-packages
-    local_dest_directory: /tmp
     pkg: "{{ item.pkg }}"
     version: "{{ item.version }}"
     namespaces: "{{ item.namespaces }}"

--- a/e2e/provision/playbooks/roles/install/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/install/tasks/main.yml
@@ -18,14 +18,15 @@
     - {pkg: nephio-stock-repos, version: nephio-stock-repos/v1, namespaces: []}
   vars:
     repo_uri: https://github.com/nephio-project/nephio-example-packages.git
-    local_dest_directory: /tmp
     pkg: "{{ item.pkg }}"
     version: "{{ item.version }}"
     namespaces: "{{ item.namespaces }}"
     context: kind-kind
+
 - name: Create gitea user password in nephio-system namespace
   become: true
   kubernetes.core.k8s:
+    context: kind-kind
     state: present
     definition:
       apiVersion: v1
@@ -37,6 +38,7 @@
       stringData:
         username: "{{ gitea_username }}"
         password: "{{ gitea_password }}"
+
 - name: Deploy Nephio webui
   ansible.builtin.include_role:
     name: kpt
@@ -44,7 +46,6 @@
     - {pkg: nephio-webui, version: v7, namespaces: [nephio-webui]}
   vars:
     repo_uri: https://github.com/nephio-project/nephio-packages.git
-    local_dest_directory: /tmp
     pkg: "{{ item.pkg }}"
     version: "{{ item.version }}"
     namespaces: "{{ item.namespaces }}"

--- a/e2e/provision/playbooks/roles/kpt/molecule/default/molecule.yml
+++ b/e2e/provision/playbooks/roles/kpt/molecule/default/molecule.yml
@@ -30,7 +30,7 @@ provisioner:
   inventory:
     group_vars:
       all:
-        local_dest_directory: /tmp
+        local_dest_directory: /tmp/kpt-molecule-test/nginx
         pkg: package-examples/nginx
         repo_uri: https://github.com/GoogleContainerTools/kpt
         version: v0.9

--- a/e2e/provision/playbooks/roles/kpt/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/kpt/tasks/main.yml
@@ -23,10 +23,10 @@
     pkg_path: "{{ pkg }}"
     version: "{{ version }}"
     local_dest_directory: "{{ workdir }}"
+    for_deployment: "{{ for_deployment | default(false) | bool }}"
     command: pkg-get
 
 - name: Get package content information
-  become: true
   kpt:
     directory: "{{ workdir }}"
     command: pkg-tree

--- a/e2e/provision/playbooks/roles/kpt/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/kpt/tasks/main.yml
@@ -8,9 +8,13 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 ##############################################################################
 
+- name: Define working directory
+  ansible.builtin.set_fact:
+    workdir: "{{ local_dest_directory | default('/tmp/kpt-pkg/' + pkg) }}"
+
 - name: Create base directory if it does not exist
   ansible.builtin.file:
-    path: "{{ local_dest_directory }}"
+    path: "{{ workdir | dirname }}"
     state: directory
 
 - name: Fetch package
@@ -18,17 +22,13 @@
     repo_uri: "{{ repo_uri }}"
     pkg_path: "{{ pkg }}"
     version: "{{ version }}"
-    local_dest_directory: "{{ local_dest_directory }}"
+    local_dest_directory: "{{ workdir }}"
     command: pkg-get
-
-- name: Get the local path
-  ansible.builtin.set_fact:
-    directory: "{{ local_dest_directory }}/{{ pkg | split('/') | last }}"
 
 - name: Get package content information
   become: true
   kpt:
-    directory: "{{ directory }}"
+    directory: "{{ workdir }}"
     command: pkg-tree
   register: kpt_pkg_tree
 
@@ -36,23 +36,16 @@
   ansible.builtin.debug:
     var: kpt_pkg_tree.stdout_lines
 
-- name: Check package has been initialized
-  ansible.builtin.stat:
-    path: "{{ directory }}/resourcegroup.yaml"
-  register: kpt_resourcegroup
-
 # TODO: Improve the render function
 - name: Render package
   become: true
   kpt:
-    pkg_path: "{{ directory }}"
+    pkg_path: "{{ workdir }}"
     command: fn-render
-  when: not kpt_resourcegroup.stat.exists
 
 - name: Get package differences between local and upstream
-  become: true
   kpt:
-    pkg_path: "{{ directory }}"
+    pkg_path: "{{ workdir }}"
     version: "{{ version }}"
     command: pkg-diff
   register: kpt_pkg_diff
@@ -61,16 +54,20 @@
   ansible.builtin.debug:
     var: kpt_pkg_diff.stdout_lines
 
+- name: Check package has been initialized
+  ansible.builtin.stat:
+    path: "{{ workdir }}/resourcegroup.yaml"
+  register: kpt_resourcegroup
+
 - name: Init package
   become: true
   kpt:
-    pkg_path: "{{ directory }}"
+    pkg_path: "{{ workdir }}"
     version: "{{ version }}"
     context: "{{ context }}"
     command: live-init
-  ignore_errors: true
   register: kpt_live_init
-  changed_when: false
+  when: not kpt_resourcegroup.stat.exists
 
 - name: Print package initialization
   ansible.builtin.debug:
@@ -79,7 +76,7 @@
 - name: Apply package
   become: true
   kpt:
-    pkg_path: "{{ directory }}"
+    pkg_path: "{{ workdir }}"
     version: "{{ version }}"
     context: "{{ context }}"
     command: live-apply
@@ -87,7 +84,6 @@
   register: kpt_apply
   until: kpt_apply is not failed
   retries: 5
-  changed_when: false
 
 - name: Wait for deployments
   ansible.builtin.include_tasks: wait_deployments.yml

--- a/e2e/provision/playbooks/roles/kpt/tasks/wait_deployments.yml
+++ b/e2e/provision/playbooks/roles/kpt/tasks/wait_deployments.yml
@@ -24,6 +24,7 @@
 - name: Wait for deployments
   become: true
   kubernetes.core.k8s:
+    context: "{{ context }}"
     definition:
       apiVersion: apps/v1
       kind: Deployment


### PR DESCRIPTION
The CI requires to constantly display progress to [avoid timeout issues](http://prow.nephio.io/view/gs/prow-nephio-sig-release/pr-logs/pull/nephio-project_test-infra/105/e2e/1669488808086736896#1:build-log.txt%3A47364). This change fixes the kpt module implementation and imports some bash instructions.