### PR TITLE
Force Ansible handlers

### DIFF
--- a/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
@@ -17,6 +17,9 @@
 - name: Set Kernel Parameters
   ansible.builtin.include_tasks: system-setup.yml
 
+- name: Force all notified handlers to run at this point
+  ansible.builtin.meta: flush_handlers
+
 - name: Get k8s clusters
   become: true
   ansible.builtin.command: kind get clusters


### PR DESCRIPTION
This change ensures all handlers operations occur before the management cluster creation.

Solves: https://github.com/nephio-project/nephio/issues/314

/cc @johnbelamaric 