### PR TITLE
Bump andrewrothstein.kpt version to 0.0.3

### DIFF
--- a/e2e/provision/galaxy-requirements.yml
+++ b/e2e/provision/galaxy-requirements.yml
@@ -18,7 +18,7 @@ roles:
   - name: andrewrothstein.kubectl
     version: v1.2.7
   - name: andrewrothstein.kpt
-    version: 0.0.1
+    version: 0.0.3
   - name: darkwizard242.cni
     version: 2.2.0
 


### PR DESCRIPTION
The [kpt Galaxy role](https://github.com/andrewrothstein/ansible-kpt) has been recently updated. This change has somehow affected the version used by this project. This change updates the version used by the Sandbox installation process.

Fixes: https://github.com/nephio-project/nephio/issues/317

\cc @denysaleksandrov 