### PR TITLE
Allow nephio home to be configured on install

### DIFF
--- a/e2e/provision/README.md
+++ b/e2e/provision/README.md
@@ -128,7 +128,7 @@ The following environment variables can be used to configure the installation:
 | ---------------------- | ---------------- | ------------- | ------------------------------------------------------ |
 | NEPHIO_USER            | userid           | ubuntu        | The user to install the sandbox on (must have sudo passwordless permissions) |
 | NEPHIO_DEBUG           | false or true    | false         | Controls debug output from the install                 |
-| NEPHIO_HOME            | a directory      | /home/$NEPHIO_USER | The directory to check out the install scripts into |
+| NEPHIO_HOME            | path             | /home/$NEPHIO_USER | The directory to check out the install scripts into |
 | NEPHIO_DEPLOYMENT_TYPE | r1 or one-summit | r1            | Controls the type of installation to be carried out    |
 | RUN_E2E                | false or true    | false         | Specifies whether end to end tests should be executed or not |
 | NEPHIO_REPO            | URL              | https://github.com/nephio-project/test-infra.git |URL of the repository to be used for installation |

--- a/e2e/provision/README.md
+++ b/e2e/provision/README.md
@@ -128,6 +128,7 @@ The following environment variables can be used to configure the installation:
 | ---------------------- | ---------------- | ------------- | ------------------------------------------------------ |
 | NEPHIO_USER            | userid           | ubuntu        | The user to install the sandbox on (must have sudo passwordless permissions) |
 | NEPHIO_DEBUG           | false or true    | false         | Controls debug output from the install                 |
+| NEPHIO_HOME            | a directory      | /home/$NEPHIO_USER | The directory to check out the install scripts into |
 | NEPHIO_DEPLOYMENT_TYPE | r1 or one-summit | r1            | Controls the type of installation to be carried out    |
 | RUN_E2E                | false or true    | false         | Specifies whether end to end tests should be executed or not |
 | NEPHIO_REPO            | URL              | https://github.com/nephio-project/test-infra.git |URL of the repository to be used for installation |

--- a/e2e/provision/init.sh
+++ b/e2e/provision/init.sh
@@ -28,10 +28,10 @@ RUN_E2E=${NEPHIO_RUN_E2E:-$(get_metadata nephio-run-e2e "false")}
 REPO=${NEPHIO_REPO:-$(get_metadata nephio-test-infra-repo "https://github.com/nephio-project/test-infra.git")}
 BRANCH=${NEPHIO_BRANCH:-$(get_metadata nephio-test-infra-branch "main")}
 NEPHIO_USER=${NEPHIO_USER:-ubuntu}
-HOME=${HOME:-/home/$NEPHIO_USER}
+HOME=${NEPHIO_HOME:-/home/$NEPHIO_USER}
 REPO_DIR=${NEPHIO_REPO_DIR:-$HOME/test-infra}
 
-echo "$DEBUG, $DEPLOYMENT_TYPE, $RUN_E2E, $REPO, $BRANCH, $NEPHIO_USER, $REPO_DIR"
+echo "$DEBUG, $DEPLOYMENT_TYPE, $RUN_E2E, $REPO, $BRANCH, $NEPHIO_USER, $HOME, $REPO_DIR"
 
 if ! command -v git >/dev/null; then
     apt-get update
@@ -52,6 +52,7 @@ cp "$REPO_DIR/e2e/provision/bash_config.sh" "$HOME/.bash_aliases"
 chown "$NEPHIO_USER:$NEPHIO_USER" "$HOME/.bash_aliases"
 
 sed -e "s/vagrant/$NEPHIO_USER/" <"$REPO_DIR/e2e/provision/nephio.yaml" >"$HOME/nephio.yaml"
+
 cd "$REPO_DIR/e2e/provision"
 export DEBUG DEPLOYMENT_TYPE
 runuser -u "$NEPHIO_USER" ./install_sandbox.sh


### PR DESCRIPTION
The default value of `/home/NEPHIO_HOME`  at line 31 in `init.sh` will never be set because `HOME` is a system variable and always has a value:

```
HOME=${HOME:-/home/$NEPHIO_USER}
```

`init.sh` is amended to pass the `NEPHIO_HOME` variable to the script and change line 31 to

```
HOME=${NEOHIO_HOME:-/home/$NEPHIO_USER}
```

This allows a user to change `HOME` if they like (by setting NEPHIO_HOME) but its likely the default value of `/home/$NEPHIO_USER` will be used in most cases.
