### PR TITLE
Version bumps in gotests adding lichen bin

### DIFF
--- a/images/gotests/Dockerfile
+++ b/images/gotests/Dockerfile
@@ -1,9 +1,11 @@
 FROM golang:1.20.5-bullseye as builder
 ARG ctrl_tools_ver=0.12.0
-RUN  cd /go/src/ && wget https://github.com/kubernetes-sigs/controller-tools/archive/refs/tags/v$ctrl_tools_ver.tar.gz && \
-     tar xf v$ctrl_tools_ver.tar.gz && \
-     cd /go/src/controller-tools-$ctrl_tools_ver/cmd/controller-gen && go build && cd /go/src/controller-tools-$ctrl_tools_ver/cmd/helpgen && \
-     go build && cd /go/src/controller-tools-$ctrl_tools_ver/cmd/type-scaffold && go build
+WORKDIR /go/src/
+ADD https://github.com/kubernetes-sigs/controller-tools/archive/refs/tags/v$ctrl_tools_ver.tar.gz ./
+RUN tar -xzf v$ctrl_tools_ver.tar.gz
+
+WORKDIR /go/src/controller-tools-$ctrl_tools_ver/
+RUN go build -o /tmp/ ./...
 
 FROM golang:1.20.5-bullseye
 RUN apt-get  update && \

--- a/images/gotests/Dockerfile
+++ b/images/gotests/Dockerfile
@@ -8,12 +8,15 @@ WORKDIR /go/src/controller-tools-$ctrl_tools_ver/
 RUN go build -o /tmp/ ./...
 
 FROM golang:1.20.5-bullseye
-RUN apt-get  update && \
-    apt-get -y install make && \
-    wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.53.3 && \
-    wget -O - -q https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s v2.16.0 && \
-    go install github.com/google/addlicense@v1.1.1 && \
-    go install github.com/uw-labs/lichen@v0.1.7
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  make=4.3-4.1 && \
+  rm -rf /var/lib/apt/lists/* && \
+  wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.53.3 && \
+  wget -O - -q https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s v2.16.0 && \
+  go install github.com/google/addlicense@v1.1.1 && \
+  go install github.com/uw-labs/lichen@v0.1.7
 
 COPY --from=builder /tmp/controller-gen /go/bin
 COPY --from=builder /tmp/helpgen /go/bin

--- a/images/gotests/Dockerfile
+++ b/images/gotests/Dockerfile
@@ -1,20 +1,23 @@
-FROM golang:1.20.4-bullseye as builder
-RUN  cd /go/src/ && wget https://github.com/kubernetes-sigs/controller-tools/archive/refs/tags/v0.12.0.tar.gz && \
-     tar xf v0.12.0.tar.gz && \
-     cd /go/src/controller-tools-0.12.0/cmd/controller-gen && go build && cd /go/src/controller-tools-0.12.0/cmd/helpgen && \
-     go build && cd /go/src/controller-tools-0.12.0/cmd/type-scaffold && go build
+FROM golang:1.20.5-bullseye as builder
+ARG ctrl_tools_ver=0.12.0
+RUN  cd /go/src/ && wget https://github.com/kubernetes-sigs/controller-tools/archive/refs/tags/v$ctrl_tools_ver.tar.gz && \
+     tar xf v$ctrl_tools_ver.tar.gz && \
+     cd /go/src/controller-tools-$ctrl_tools_ver/cmd/controller-gen && go build && cd /go/src/controller-tools-$ctrl_tools_ver/cmd/helpgen && \
+     go build && cd /go/src/controller-tools-$ctrl_tools_ver/cmd/type-scaffold && go build
 
-FROM golang:1.20.4-bullseye
+FROM golang:1.20.5-bullseye
 RUN apt-get  update && \
     apt-get -y install make && \
-    wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.52.2 && \
-    wget -O - -q https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s v2.15.0 && \
-    go install github.com/google/addlicense@v1.1.1
+    wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.53.3 && \
+    wget -O - -q https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s v2.16.0 && \
+    go install github.com/google/addlicense@v1.1.1 && \
+    go install github.com/uw-labs/lichen@v0.1.7
 
-COPY --from=builder /go/src/controller-tools-0.12.0/cmd/controller-gen/controller-gen /go/bin
-COPY --from=builder /go/src/controller-tools-0.12.0/cmd/helpgen/helpgen /go/bin
-COPY --from=builder /go/src/controller-tools-0.12.0/cmd/type-scaffold/type-scaffold /go/bin
+ARG ctrl_tools_ver=0.12.0
+COPY --from=builder /go/src/controller-tools-$ctrl_tools_ver/cmd/controller-gen/controller-gen /go/bin
+COPY --from=builder /go/src/controller-tools-$ctrl_tools_ver/cmd/helpgen/helpgen /go/bin
+COPY --from=builder /go/src/controller-tools-$ctrl_tools_ver/cmd/type-scaffold/type-scaffold /go/bin
 
-COPY checklicense.sh /usr/local/bin/ 
-COPY lichen.sh /usr/local/bin/
+COPY lichen.sh checklicense.sh /usr/local/bin/
+COPY lichen.yaml /etc/
 RUN chmod +x /usr/local/bin/*.sh

--- a/images/gotests/Dockerfile
+++ b/images/gotests/Dockerfile
@@ -15,10 +15,9 @@ RUN apt-get  update && \
     go install github.com/google/addlicense@v1.1.1 && \
     go install github.com/uw-labs/lichen@v0.1.7
 
-ARG ctrl_tools_ver=0.12.0
-COPY --from=builder /go/src/controller-tools-$ctrl_tools_ver/cmd/controller-gen/controller-gen /go/bin
-COPY --from=builder /go/src/controller-tools-$ctrl_tools_ver/cmd/helpgen/helpgen /go/bin
-COPY --from=builder /go/src/controller-tools-$ctrl_tools_ver/cmd/type-scaffold/type-scaffold /go/bin
+COPY --from=builder /tmp/controller-gen /go/bin
+COPY --from=builder /tmp/helpgen /go/bin
+COPY --from=builder /tmp/type-scaffold /go/bin
 
 COPY lichen.sh checklicense.sh /usr/local/bin/
 COPY lichen.yaml /etc/


### PR DESCRIPTION
golang:1.20.4-bullseye -> golang:1.20.5-bullseye
golangci-lint 1.52.2 -> 1.53.3
gosec 2.15.0 -> 2.16.0