### PR TITLE
Align Network topology values

### DIFF
--- a/e2e/provision/README.md
+++ b/e2e/provision/README.md
@@ -458,7 +458,7 @@ is not yet in this release.
 
 ```bash
 workers=""
-for context in $(kubectl config get-contexts --no-headers --output name); do
+for context in $(kubectl config get-contexts --no-headers --output name | sort); do
     workers+=$(kubectl get nodes -l node-role.kubernetes.io/control-plane!= -o jsonpath='{range .items[*]}"{.metadata.name}",{"\n"}{end}' --context "$context")
 done
 echo "{\"workers\":[${workers::-1}]}" | tee /tmp/vars.json

--- a/e2e/tests/002.sh
+++ b/e2e/tests/002.sh
@@ -45,7 +45,7 @@ done
 
 # Inter-connect worker nodes
 workers=""
-for cluster in $(kubectl get cluster -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' --kubeconfig "$kubeconfig"); do
+for cluster in $(kubectl get cluster -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' --sort-by=.metadata.name --kubeconfig "$kubeconfig"); do
     _kubeconfig=$(k8s_get_capi_kubeconfig "$kubeconfig" "default" "$cluster")
     workers+=$(kubectl get nodes -l node-role.kubernetes.io/control-plane!= -o jsonpath='{range .items[*]}"{.metadata.name}",{"\n"}{end}' --kubeconfig "$_kubeconfig")
 done

--- a/e2e/tests/003-network-topo.yaml
+++ b/e2e/tests/003-network-topo.yaml
@@ -22,11 +22,11 @@ spec:
         nephio.org/cluster-name: edge02
   links:
   - endpoints: 
-    - { nodeName: srl, interfaceName: e1-1}
-    - { nodeName: regional, interfaceName: eth1}
-  - endpoints: 
-    - { nodeName: srl, interfaceName: e1-5}
+    - { nodeName: srl, interfaceName: e1-0}
     - { nodeName: edge01, interfaceName: eth1}
   - endpoints: 
-    - { nodeName: srl, interfaceName: e1-9}
+    - { nodeName: srl, interfaceName: e1-1}
     - { nodeName: edge02, interfaceName: eth1}
+  - endpoints:
+    - { nodeName: srl, interfaceName: e1-2}
+    - { nodeName: regional, interfaceName: eth1}


### PR DESCRIPTION
This change pretends to make consistent the port values used by `containerlab` and the `RawTopology` resource