### PR TITLE
add fedora support

### DIFF
--- a/e2e/provision/init.sh
+++ b/e2e/provision/init.sh
@@ -34,8 +34,21 @@ REPO_DIR=${NEPHIO_REPO_DIR:-$HOME/test-infra}
 echo "$DEBUG, $DEPLOYMENT_TYPE, $RUN_E2E, $REPO, $BRANCH, $NEPHIO_USER, $HOME, $REPO_DIR"
 
 if ! command -v git >/dev/null; then
-    apt-get update
-    apt-get install -y git
+    source /etc/os-release || source /usr/lib/os-release
+    case ${ID,,} in
+    ubuntu | debian)
+        apt-get update
+        apt-get install -y git
+        ;;
+    rhel | centos | fedora | rocky)
+        PKG_MANAGER=$(command -v dnf || command -v yum)
+        $PKG_MANAGER install git -y
+        ;;
+    *)
+        echo "OS not supported"
+        exit
+        ;;
+    esac
 fi
 
 if [ ! -d "$REPO_DIR" ]; then

--- a/e2e/provision/install_sandbox.sh
+++ b/e2e/provision/install_sandbox.sh
@@ -29,9 +29,23 @@ function get_status {
 }
 
 # Install dependencies for it's ansible execution
-sudo apt-get update
-sudo -E DEBIAN_FRONTEND=noninteractive apt-get remove -q -y python3-openssl
-sudo -E NEEDRESTART_SUSPEND=1 DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" --allow-downgrades --allow-remove-essential --allow-change-held-packages -fuy install -q -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" python3-pip
+source /etc/os-release || source /usr/lib/os-release
+case ${ID,,} in
+ubuntu | debian)
+    sudo apt-get update
+    sudo -E DEBIAN_FRONTEND=noninteractive apt-get remove -q -y python3-openssl
+    sudo -E NEEDRESTART_SUSPEND=1 DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" --allow-downgrades --allow-remove-essential --allow-change-held-packages -fuy install -q -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" python3-pip
+    ;;
+rhel | centos | fedora | rocky)
+    PKG_MANAGER=$(command -v dnf || command -v yum)
+    sudo $PKG_MANAGER install python3-pip -y
+    ;;
+*)
+    echo "OS not supported"
+    exit
+    ;;
+esac
+
 sudo pip install -r requirements.txt
 ansible-galaxy role install -r galaxy-requirements.yml
 ansible-galaxy collection install -r galaxy-requirements.yml

--- a/e2e/provision/playbooks/cluster.yml
+++ b/e2e/provision/playbooks/cluster.yml
@@ -60,3 +60,14 @@
       ansible.builtin.apt:
         deb: "https://github.com/srl-labs/containerlab/releases/download/v{{ clab_version }}/containerlab_{{ clab_version }}_linux_{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}.deb"
       when: ansible_os_family == 'Debian' and ansible_architecture in ('arm64', 'x86_64')
+    - name: Install container lab on RedHat family OS
+      block:
+        - name: Install container lab
+          ansible.builtin.yum:
+            name: "https://github.com/srl-labs/containerlab/releases/download/v{{ clab_version }}/containerlab_{{ clab_version }}_linux_{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}.rpm"
+            state: present
+            disable_gpg_check: true
+        - name: Configure SELinux for clab
+          ansible.builtin.shell: setsebool -P selinuxuser_execmod 1
+      become: true
+      when: ansible_os_family == 'RedHat' and ansible_architecture in ('arm64', 'x86_64')

--- a/e2e/provision/playbooks/roles/bootstrap/README.md
+++ b/e2e/provision/playbooks/roles/bootstrap/README.md
@@ -47,7 +47,7 @@ flowchart TD
     B --> C(Checking host has minimum RAM)
     C --> D(Checking host has minimal kernel version)
     D -->|Load gtp5g kernel module| E(Load OS specific variables)
-    E --> F(Install compilation packages)
+    E --> F(nstall compilation packages and kernel development tools on Debian/RedHat)
     F --> G{ansible_os_family == 'Debian/RedHat'?}
     G -- true --> H(Install Debian kernel development tools)
     H --> I(Install Debian/RedHat kernel development tools) --> J

--- a/e2e/provision/playbooks/roles/bootstrap/README.md
+++ b/e2e/provision/playbooks/roles/bootstrap/README.md
@@ -47,7 +47,7 @@ flowchart TD
     B --> C(Checking host has minimum RAM)
     C --> D(Checking host has minimal kernel version)
     D -->|Load gtp5g kernel module| E(Load OS specific variables)
-    E --> F(nstall compilation packages and kernel development tools on Debian/RedHat)
+    E --> F(Install compilation packages and kernel development tools on Debian/RedHat)
     F --> G{ansible_os_family == 'Debian/RedHat'?}
     G -- true --> H(Install Debian kernel development tools)
     H --> I(Install Debian/RedHat kernel development tools) --> J

--- a/e2e/provision/playbooks/roles/bootstrap/README.md
+++ b/e2e/provision/playbooks/roles/bootstrap/README.md
@@ -48,9 +48,9 @@ flowchart TD
     C --> D(Checking host has minimal kernel version)
     D -->|Load gtp5g kernel module| E(Load OS specific variables)
     E --> F(Install compilation packages)
-    F --> G{ansible_os_family == 'Debian'?}
+    F --> G{ansible_os_family == 'Debian/RedHat'?}
     G -- true --> H(Install Debian kernel development tools)
-    H --> I(Install Debian kernel development tools) --> J
+    H --> I(Install Debian/RedHat kernel development tools) --> J
     G -- false --> J(Get gtp5g module information)
     J --> K(Create gtp5g destination folder)
     K --> L(Extract gtp5g driver source code)

--- a/e2e/provision/playbooks/roles/bootstrap/molecule/default/molecule.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/molecule/default/molecule.yml
@@ -29,6 +29,10 @@ platforms:
     box: generic/ubuntu2204
     provider_options:
       gui: false
+  - name: fedora34
+    box: generic/fedora34
+    provider_options:
+      gui: false
 provisioner:
   name: ansible
   env:

--- a/e2e/provision/playbooks/roles/bootstrap/molecule/default/prepare.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/molecule/default/prepare.yml
@@ -15,6 +15,7 @@
       ansible.builtin.raw: apt-get update --allow-releaseinfo-change
       become: true
       changed_when: false
+      when: ansible_distribution == 'Ubuntu'
     - name: Install pip package
       become: true
       ansible.builtin.package:

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/load-gtp5g-module.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/load-gtp5g-module.yml
@@ -17,19 +17,13 @@
         - "{{ ansible_os_family | lower }}.yml"
       skip: true
 
-- name: Install compilation packages
+- name: Install compilation packages and kernel development tools on {{ ansible_os_family }}
   become: true
   ansible.builtin.package:
     name: "{{ item }}"
     state: present
   with_items: "{{ build_pkgs }}"
-
-- name: Install Debian kernel development tools
-  become: true
-  ansible.builtin.package:
-    name: "linux-headers-{{ ansible_kernel }}"
-    state: present
-  when: ansible_os_family == 'Debian'
+  when: ansible_os_family in ['Debian', 'RedHat']
 
 - name: Get gtp5g module information
   ansible.builtin.command: modinfo gtp5g

--- a/e2e/provision/playbooks/roles/bootstrap/vars/redhat.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/vars/redhat.yml
@@ -9,7 +9,8 @@
 ##############################################################################
 
 build_pkgs:
-  - gcc
   - make
-  - gcc-10
-  - linux-headers-{{ ansible_kernel }}
+  - kernel-devel
+  - kernel-headers
+  - elfutils-libelf
+  - elfutils-libelf-devel

--- a/e2e/provision/playbooks/roles/bootstrap/vars/ubuntu-22.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/vars/ubuntu-22.yml
@@ -12,3 +12,4 @@ build_pkgs:
   - gcc
   - make
   - gcc-12
+  - linux-headers-{{ ansible_kernel }}

--- a/e2e/provision/playbooks/roles/kpt/molecule/default/prepare.yml
+++ b/e2e/provision/playbooks/roles/kpt/molecule/default/prepare.yml
@@ -15,6 +15,7 @@
       ansible.builtin.raw: apt-get update --allow-releaseinfo-change
       become: true
       changed_when: false
+      when: ansible_distribution == 'Ubuntu'
     - name: Install pip package
       become: true
       ansible.builtin.package:


### PR DESCRIPTION
This PR adds support for Fedora34 that has the kernel version of 5.17.6. Was able to execute the steps at https://github.com/nephio-project/test-infra/blob/main/e2e/provision/README.md successfully.

Note:
-  Fedora versions above 34 have kernel version greater than 6.0.0 which does not support building and installing gtp5g kernel modules.
-  PR was tested on a Fedora VM running on baremetal
- Fedora 34 VM on gcp cloud does not allow ssh login and hence was unable to test out in gcp fedora34 VM.