### PR TITLE
Enable Google vagrant provider

### DIFF
--- a/e2e/provision/Vagrantfile
+++ b/e2e/provision/Vagrantfile
@@ -15,6 +15,7 @@ Vagrant.configure('2') do |config|
   # rubocop:enable Metrics/BlockLength
   config.vm.provider :libvirt
   config.vm.provider :virtualbox
+  config.vm.provider :google
 
   config.vm.box = 'generic/ubuntu2004'
   config.vm.box_check_update = false
@@ -38,7 +39,7 @@ Vagrant.configure('2') do |config|
       NEPHIO_DEBUG: ENV.fetch('DEBUG', true),
       NEPHIO_DEPLOYMENT_TYPE: ENV.fetch('DEPLOYMENT_TYPE', 'r1'),
       NEPHIO_RUN_E2E: ENV.fetch('RUN_E2E', false),
-      NEPHIO_USER: 'vagrant',
+      NEPHIO_USER: ENV.fetch('NEPHIO_USER', 'vagrant'),
       NEPHIO_REPO_DIR: '/opt/test-infra',
       E2EDIR: '/opt/test-infra/e2e'
     }
@@ -76,6 +77,21 @@ Vagrant.configure('2') do |config|
     v.management_network_address = '10.0.2.0/24'
     v.management_network_name = 'administration'
     v.cpu_mode = 'host-passthrough'
+  end
+
+  config.vm.provider :google do |v, override|
+    v.google_project_id = ENV['GOOGLE_PROJECT_ID']
+    v.google_json_key_location = ENV.fetch('GOOGLE_JSON_KEY_LOCATION',
+                                           '~/.config/gcloud/application_default_credentials.json')
+    v.image_project_id = 'ubuntu-os-cloud'
+    v.image_family = 'ubuntu-2004-lts'
+    v.machine_type = 'e2-standard-16'
+    v.disk_size = 200
+    v.name = "sandbox-vm-#{[*('a'..'z')].sample(6).join}"
+
+    override.vm.box = 'google/gce'
+    override.ssh.username = ENV['USER']
+    override.ssh.private_key_path = '~/.ssh/id_rsa'
   end
 
   if !ENV['http_proxy'].nil? && !ENV['https_proxy'].nil? && Vagrant.has_plugin?('vagrant-proxyconf')

--- a/e2e/provision/init.sh
+++ b/e2e/provision/init.sh
@@ -27,7 +27,7 @@ DEPLOYMENT_TYPE=${NEPHIO_DEPLOYMENT_TYPE:-$(get_metadata nephio-setup-type "r1")
 RUN_E2E=${NEPHIO_RUN_E2E:-$(get_metadata nephio-run-e2e "false")}
 REPO=${NEPHIO_REPO:-$(get_metadata nephio-test-infra-repo "https://github.com/nephio-project/test-infra.git")}
 BRANCH=${NEPHIO_BRANCH:-$(get_metadata nephio-test-infra-branch "main")}
-NEPHIO_USER=${NEPHIO_USER:-ubuntu}
+NEPHIO_USER=${NEPHIO_USER:-$(get_metadata nephio-user "ubuntu")}
 HOME=${NEPHIO_HOME:-/home/$NEPHIO_USER}
 REPO_DIR=${NEPHIO_REPO_DIR:-$HOME/test-infra}
 

--- a/e2e/provision/install_sandbox.sh
+++ b/e2e/provision/install_sandbox.sh
@@ -15,19 +15,6 @@ set -o nounset
 
 export HOME=${HOME:-/home/ubuntu/}
 
-# get_status() - Print the current status of the management cluster
-function get_status {
-    set +o xtrace
-    printf "CPU usage: "
-    grep 'cpu ' /proc/stat | awk '{usage=($2+$4)*100/($2+$4+$5)} END {print usage " %"}'
-    printf "Memory free(Kb):"
-    awk -v low="$(grep low /proc/zoneinfo | awk '{k+=$2}END{print k}')" '{a[$1]=$2}  END{ print a["MemFree:"]+a["Active(file):"]+a["Inactive(file):"]+a["SReclaimable:"]-(12*low);}' /proc/meminfo
-    echo "Kubernetes Events:"
-    sudo kubectl get events
-    echo "Kubernetes Resources:"
-    sudo kubectl get all -A -o wide
-}
-
 # Install dependencies for it's ansible execution
 sudo apt-get update
 sudo -E DEBIAN_FRONTEND=noninteractive apt-get remove -q -y python3-openssl
@@ -54,8 +41,6 @@ if [ "${DEPLOYMENT_TYPE:-r1}" == "one-summit" ]; then
     done
     popd >/dev/null
 else
-    trap get_status ERR
-
     mkdir -p ~/.ssh/
     touch ~/.ssh/config
     if ! grep -q "StrictHostKeyChecking no" ~/.ssh/config; then


### PR DESCRIPTION
This change allows using the [`vagrant` tool](https://www.vagrantup.com/) to provision an instance in GCE. It needs some [setup](https://github.com/mitchellh/vagrant-google/#google-cloud-platform-setup) previous to its execution:

```bash
GOOGLE_PROJECT_ID=<project_id> GOOGLE_JSON_KEY_LOCATION=<path> NEPHIO_USER=$USER vagrant up --provider google
```

> Note: The `get_status` offers current information about the VM in case that an error happens.