### PR TITLE
008.sh corrects the metrics check

### DIFF
--- a/e2e/tests/008.sh
+++ b/e2e/tests/008.sh
@@ -35,7 +35,7 @@ function _check_scale {
     local current=$3
 
     echo "UPF - Comparing the new $metric after scaling"
-    if [ "$previous" -le "$current" ]; then
+    if [ "$previous" -ge "$current" ]; then
         echo "UPF $metric scaling Failed"
         exit 1
     fi


### PR DESCRIPTION
@@ -35,7 +35,7 @@ function _check_scale {
     
     echo "UPF - Comparing the new $metric after scaling"
-    if [ "$previous" -le "$current" ]; then
+    if [ "$previous" -ge "$current" ]; then
         echo "UPF $metric scaling Failed"
         exit 1
     fi