### PR TITLE
Delay the approval process

### DIFF
--- a/e2e/tests/001.sh
+++ b/e2e/tests/001.sh
@@ -34,6 +34,7 @@ kpt fn eval --image "gcr.io/kpt-fn/set-labels:v0.2.0" regional -- "nephio.org/si
 kpt alpha rpkg push -n default "$regional_pkg_rev" regional
 
 kpt alpha rpkg propose -n default "$regional_pkg_rev"
+sleep 5
 kpt alpha rpkg approve -n default "$regional_pkg_rev"
 
 k8s_wait_exists "$kubeconfig" 600 "default" "workloadcluster" "regional"

--- a/e2e/tests/003.sh
+++ b/e2e/tests/003.sh
@@ -45,6 +45,7 @@ upstream_pkg_rev=$(kpt alpha rpkg get --name free5gc-cp --revision v1 -o jsonpat
 pkg_rev=$(kpt alpha rpkg clone -n default "$upstream_pkg_rev" --repository regional free5gc-cp | cut -f 1 -d ' ')
 
 kpt alpha rpkg propose -n default "$pkg_rev"
+sleep 5
 kpt alpha rpkg approve -n default "$pkg_rev"
 
 k8s_wait_exists "$regional_kubeconfig" 600 "free5gc-cp" "statefulset" "mongodb"

--- a/e2e/tests/008.sh
+++ b/e2e/tests/008.sh
@@ -98,6 +98,7 @@ for cluster in "edge01" "edge02"; do
 
     echo "Proposing update"
     kpt alpha rpkg propose -n default "$upf_pkg_rev"
+    sleep 5
 
     echo "Approving update"
     kpt alpha rpkg approve -n default "$upf_pkg_rev"

--- a/e2e/tests/009.sh
+++ b/e2e/tests/009.sh
@@ -133,6 +133,7 @@ kpt alpha rpkg push -n default "$smf_pkg_rev" $ws
 
 echo "Proposing update"
 kpt alpha rpkg propose -n default "$smf_pkg_rev"
+sleep 5
 
 echo "Approving update"
 kpt alpha rpkg approve -n default "$smf_pkg_rev"


### PR DESCRIPTION
Apparently, [Porch requires some delay](http://prow.nephio.io/view/gs/prow-nephio-sig-release/pr-logs/pull/nephio-project_test-infra/144/e2e/1674422995407343616#1:build-log.txt%3A53340) to reflect package revisions, this workaround will give time to mitigate that issue.

```console
google_compute_instance.e2e_instances[0] (remote-exec): + kpt alpha rpkg propose -n default regional-8bcf50b42723a4f7462e1d41264515cdc7546d1b
google_compute_instance.e2e_instances[0] (remote-exec): regional-8bcf50b42723a4f7462e1d41264515cdc7546d1b proposed
google_compute_instance.e2e_instances[0] (remote-exec): + kpt alpha rpkg approve -n default regional-8bcf50b42723a4f7462e1d41264515cdc7546d1b
google_compute_instance.e2e_instances[0]: Still creating... [30m0s elapsed]
google_compute_instance.e2e_instances[0] (remote-exec): regional-8bcf50b42723a4f7462e1d41264515cdc7546d1b failed (Internal error occurred: packagerevs.config.porch.kpt.dev "regional-8bcf50b42723a4f7462e1d41264515cdc7546d1b" not found)
google_compute_instance.e2e_instances[0] (remote-exec): Error: errors:
google_compute_instance.e2e_instances[0] (remote-exec):   Internal error occurred: packagerevs.config.porch.kpt.dev "regional-8bcf50b42723a4f7462e1d41264515cdc7546d1b" not found 
```

> Note: This should be fixed later with `k8s_wait_exists` function
