### PR TITLE
Bump Kubernetes to v1.27.1 in management cluster

### DIFF
--- a/e2e/provision/playbooks/roles/bootstrap/README.md
+++ b/e2e/provision/playbooks/roles/bootstrap/README.md
@@ -18,7 +18,7 @@ Available variables are listed below, along with default values (see defaults/ma
 | host_min_cpu_ram         | no       | 16         |                           | Minimum RAM required (GB)                                     |
 | host_min_root_disk_space | no       | 50         |                           | Minimum disk space required (GB)                              |
 | container_engine         | no       | docker     | docker                    | Container engine utilized for the management cluster creation |
-| kubernetes_version       | no       | v1.26.3    |                           | Kubernetes version used for the management cluster            |
+| kubernetes_version       | no       | v1.27.1    |                           | Kubernetes version used for the management cluster            |
 | gitea_postgres_password  | no       | c2VjcmV0   |                           | `postgres-password` secret value for gitea database service   |
 | gitea_db_password        | no       | c2VjcmV0   |                           | `password` secret value for gitea service                     |
 | gitea_username           | no       | nephio     |                           | Gitea admin user name                                         |

--- a/e2e/provision/playbooks/roles/bootstrap/defaults/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/defaults/main.yml
@@ -13,7 +13,7 @@ host_min_cpu_ram: 16  # minimum required CPU RAM before install; value in GB
 host_min_root_disk_space: 50  # minimum required disk space before install; value in GB
 
 container_engine: docker
-kubernetes_version: v1.26.3
+kubernetes_version: v1.27.1
 
 gitea_postgres_password: c2VjcmV0  # echo -n "secret" | base64
 gitea_db_password: c2VjcmV0


### PR DESCRIPTION
It seems like Porch has some race conditions in older Kubernetes versions, this is an attempt to mitigate them.