### PR TITLE
Use non-ambigous value for cluster resources

### DIFF
--- a/e2e/provision/hacks/inter-connect_workers.sh
+++ b/e2e/provision/hacks/inter-connect_workers.sh
@@ -21,7 +21,7 @@ source "${LIBDIR}/k8s.sh"
 kubeconfig="$HOME/.kube/config"
 
 workers=""
-for cluster in $(kubectl get cluster -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' --sort-by=.metadata.name --kubeconfig "$kubeconfig"); do
+for cluster in $(kubectl get cl -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' --sort-by=.metadata.name --kubeconfig "$kubeconfig"); do
     _kubeconfig=$(k8s_get_capi_kubeconfig "$kubeconfig" "default" "$cluster")
     workers+=$(kubectl get nodes -l node-role.kubernetes.io/control-plane!= -o jsonpath='{range .items[*]}"{.metadata.name}",{"\n"}{end}' --kubeconfig "$_kubeconfig")
 done


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
"cluster" seems to no longer be non-ambiguous. Another question is do we need clusterregistry clusters? Is that needed for CAPI?

