### PR TITLE
Fix init.sh to work with a tag

### DIFF
--- a/e2e/provision/init.sh
+++ b/e2e/provision/init.sh
@@ -86,7 +86,12 @@ if [ ! -d "$REPO_DIR" ]; then
     runuser -u "$NEPHIO_USER" git clone "$REPO" "$REPO_DIR"
     if [[ $BRANCH != "main" ]]; then
         pushd "$REPO_DIR" >/dev/null
-        runuser -u "$NEPHIO_USER" -- git checkout -b "$BRANCH" --track "origin/$BRANCH"
+        TAG=$(git tag --list $BRANCH)
+        if [[ $TAG == $BRANCH ]]; then
+            runuser -u "$NEPHIO_USER" -- git checkout --detach "$TAG"
+        else
+            runuser -u "$NEPHIO_USER" -- git checkout -b "$BRANCH" --track "origin/$BRANCH"
+        fi
         popd >/dev/null
     fi
 fi

--- a/e2e/provision/init.sh
+++ b/e2e/provision/init.sh
@@ -86,7 +86,7 @@ if [ ! -d "$REPO_DIR" ]; then
     runuser -u "$NEPHIO_USER" git clone "$REPO" "$REPO_DIR"
     if [[ $BRANCH != "main" ]]; then
         pushd "$REPO_DIR" >/dev/null
-        TAG=$(runuser -u "$NEPHIO_USER" git tag --list $BRANCH)
+        TAG=$(runuser -u "$NEPHIO_USER" -- git tag --list $BRANCH)
         if [[ $TAG == $BRANCH ]]; then
             runuser -u "$NEPHIO_USER" -- git checkout --detach "$TAG"
         else

--- a/e2e/provision/init.sh
+++ b/e2e/provision/init.sh
@@ -86,7 +86,7 @@ if [ ! -d "$REPO_DIR" ]; then
     runuser -u "$NEPHIO_USER" git clone "$REPO" "$REPO_DIR"
     if [[ $BRANCH != "main" ]]; then
         pushd "$REPO_DIR" >/dev/null
-        TAG=$(git tag --list $BRANCH)
+        TAG=$(runuser -u "$NEPHIO_USER" git tag --list $BRANCH)
         if [[ $TAG == $BRANCH ]]; then
             runuser -u "$NEPHIO_USER" -- git checkout --detach "$TAG"
         else


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**
init.sh currently only works if the value passed into nephio-test-infra-branch is a *branch*, not if it is a *tag*. This is a problem for creating instructions that enable building a sandbox from a single command, based on a tag (e.g., v1.0.0).

**Which issue(s) this PR fixes**:
Partially fixes https://github.com/nephio-project/nephio/issues/328

This will fix it for v1.0.1 and later. For v1.0.0, we need to create a branch to use, and tweak the instructions to use that branch name. Either that, or we need to move the v1.0.0 tag to a commit after this PR merges.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
