### PR TITLE
Avoid aborting script if subshell command fails

### DIFF
--- a/e2e/tests/009.sh
+++ b/e2e/tests/009.sh
@@ -87,14 +87,14 @@ while [[ $retries -gt 0 ]]; do
 
     modified=false
     echo "Pushing update"
-    output=$(kpt alpha rpkg push -n default "$smf_pkg_rev" $ws 2>&1)
+    output=$(kpt alpha rpkg push -n default "$smf_pkg_rev" $ws 2>&1 || rc=$?)
     if [[ $output =~ "modified" ]]; then
         modified=true
     fi
 
     if [[ $modified == false ]]; then
         echo "Proposing update"
-        output=$(kpt alpha rpkg propose -n default "$smf_pkg_rev" 2>&1)
+        output=$(kpt alpha rpkg propose -n default "$smf_pkg_rev" 2>&1 || rc=$?)
         if [[ $output =~ "modified" ]]; then
             modified=true
         else
@@ -104,7 +104,7 @@ while [[ $retries -gt 0 ]]; do
 
     if [[ $modified == false ]]; then
         echo "Approving update"
-        output=$(kpt alpha rpkg approve -n default "$smf_pkg_rev" 2>&1)
+        output=$(kpt alpha rpkg approve -n default "$smf_pkg_rev" 2>&1 || rc=$?)
         if [[ $output =~ "modified" ]]; then
             modified=true
         fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
