### PR TITLE
Fix kernel modules installation

### DIFF
--- a/e2e/provision/playbooks/roles/bootstrap/tasks/load-sctp-module.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/load-sctp-module.yml
@@ -8,14 +8,20 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 ##############################################################################
 
-- name: install sctp on {{ ansible_os_family }}
-  become: yes
+- name: Install sctp on {{ ansible_os_family }}
+  become: true
   ansible.builtin.package:
-    name: "kernel-modules-extra-{{ ansible_kernel }}"
+    name: "{{ item }}"
   when: ansible_os_family == 'RedHat'
+  ignore_errors: true
+  register: kernel_modules_install
+  until: kernel_modules_install is not failed
+  loop:
+    - "kernel-modules-extra-{{ ansible_kernel }}"
+    - kernel-modules-extra
 
-- name: load the sctp kernel module
-  become: yes
+- name: Load the sctp kernel module
+  become: true
   community.general.modprobe:
     name: sctp
     state: present


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Some Fedora 34 distros don't have support for specific kernel modules packages, this results in failures during the installation of `"kernel-modules-extra-{{ ansible_kernel }}"` package. This change tries to cover all the scenarios and fixes some linting issues

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
