### PR TITLE
Add docker registry mirror support

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -2,3 +2,4 @@ terraform/.terraform.lock.hcl
 terraform/.terraform/
 terraform/terraform.tfstate
 terraform/terraform.tfstate.backup
+/provision/.tox

--- a/e2e/provision/playbooks/cluster.yml
+++ b/e2e/provision/playbooks/cluster.yml
@@ -24,6 +24,12 @@
       become: true
       when: (container_engine is not defined) or (container_engine == "docker")
       block:
+        - name: Add registry mirrors to docker configuration
+          ansible.builtin.set_fact:
+            docker_engine_daemon_json: 
+              registry-mirrors: "{{ lookup('ansible.builtin.env', 'DOCKER_REGISTRY_MIRRORS') }}"
+          when: lookup('ansible.builtin.env', 'DOCKER_REGISTRY_MIRRORS')
+
         - name: Install docker binaries
           ansible.builtin.include_role:
             name: andrewrothstein.docker_engine

--- a/e2e/provision/playbooks/cluster.yml
+++ b/e2e/provision/playbooks/cluster.yml
@@ -26,7 +26,7 @@
       block:
         - name: Add registry mirrors to docker configuration
           ansible.builtin.set_fact:
-            docker_engine_daemon_json: 
+            docker_engine_daemon_json:
               registry-mirrors: "{{ lookup('ansible.builtin.env', 'DOCKER_REGISTRY_MIRRORS') }}"
           when: lookup('ansible.builtin.env', 'DOCKER_REGISTRY_MIRRORS')
 

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/create-mgmt.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/create-mgmt.yml
@@ -36,7 +36,7 @@
       containerdConfigPatches:
         - |-
           [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-            endpoint = {{ lookup('ansible.builtin.env', 'DOCKER_REGISTRY_MIRRORS') | from_json }}              
+            endpoint = {{ lookup('ansible.builtin.env', 'DOCKER_REGISTRY_MIRRORS') | from_json }}
       {% endif %}
   when: not 'kind' in bootstrap_kind_get_cluster.stdout
   changed_when: true

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/create-mgmt.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/create-mgmt.yml
@@ -32,7 +32,7 @@
           extraMounts:
             - hostPath: /var/run/{{ container_engine }}.sock
               containerPath: /var/run/{{ container_engine }}.sock
-      {% if lookup('ansible.builtin.env', 'DOCKER_REGISTRY_MIRRORS')  %}
+      {% if lookup('ansible.builtin.env', 'DOCKER_REGISTRY_MIRRORS') %}
       containerdConfigPatches:
         - |-
           [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/create-mgmt.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/create-mgmt.yml
@@ -32,6 +32,12 @@
           extraMounts:
             - hostPath: /var/run/{{ container_engine }}.sock
               containerPath: /var/run/{{ container_engine }}.sock
+      {% if lookup('ansible.builtin.env', 'DOCKER_REGISTRY_MIRRORS')  %}
+      containerdConfigPatches:
+        - |-
+          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+            endpoint = {{ lookup('ansible.builtin.env', 'DOCKER_REGISTRY_MIRRORS') | from_json }}              
+      {% endif %}
   when: not 'kind' in bootstrap_kind_get_cluster.stdout
   changed_when: true
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
It enables the ansible playbook to set docker registry mirrors for the docker engine in the sandbox VM and also for the management kind cluster deployed by the playbook. The list of registry mirrors is expected to be in the DOCKER_REGISTRY_MIRRORS environment variable in JSON format.

We need this, because in some company intranets DockerHub access has to go through a company-wide docker registry mirror by company policy.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Enable setting docker registry mirrors in the sandbox environment.
```
