### PR TITLE
Make Fedora job non-blocking

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -69,6 +69,7 @@ presubmits:
     labels:
     run_if_changed: '^e2e/'
     skip_report: false
+    optional: true
     decorate: true
     cluster: default
     spec:


### PR DESCRIPTION
Setting Fedora job as optional will not block merge to e2e

<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Setting Fedora job as optional will not block merge to e2e

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
