### PR TITLE
look up environment variables instead of passing as extra-args

### DIFF
--- a/e2e/provision/init.sh
+++ b/e2e/provision/init.sh
@@ -60,8 +60,10 @@ BRANCH=${NEPHIO_BRANCH:-$(get_metadata nephio-test-infra-branch "main")}
 NEPHIO_USER=${NEPHIO_USER:-$(get_metadata nephio-user "ubuntu")}
 HOME=${NEPHIO_HOME:-/home/$NEPHIO_USER}
 REPO_DIR=${NEPHIO_REPO_DIR:-$HOME/test-infra}
+DOCKERHUB_USERNAME=${DOCKERHUB_USERNAME:-""}
+DOCKERHUB_TOKEN=${DOCKERHUB_TOKEN:-""}
 
-echo "$DEBUG, $DEPLOYMENT_TYPE, $RUN_E2E, $REPO, $BRANCH, $NEPHIO_USER, $HOME, $REPO_DIR"
+echo "$DEBUG, $DEPLOYMENT_TYPE, $RUN_E2E, $REPO, $BRANCH, $NEPHIO_USER, $HOME, $REPO_DIR, $DOCKERHUB_USERNAME, $DOCKERHUB_TOKEN"
 trap get_status ERR
 
 if ! command -v git >/dev/null; then
@@ -105,7 +107,7 @@ sed -e "s/vagrant/$NEPHIO_USER/" <"$REPO_DIR/e2e/provision/nephio.yaml" >"$HOME/
 # Sandbox Creation
 int_start=$(date +%s)
 cd "$REPO_DIR/e2e/provision"
-export DEBUG DEPLOYMENT_TYPE
+export DEBUG DEPLOYMENT_TYPE DOCKERHUB_USERNAME DOCKERHUB_TOKEN
 runuser -u "$NEPHIO_USER" ./install_sandbox.sh
 printf "%s secs\n" "$(($(date +%s) - int_start))"
 

--- a/e2e/provision/install_sandbox.sh
+++ b/e2e/provision/install_sandbox.sh
@@ -89,9 +89,17 @@ if [ "${DEPLOYMENT_TYPE:-r1}" == "one-summit" ]; then
 else
     # Management cluster creation
     if [[ ${DEBUG:-false} != "true" ]]; then
-        ansible-playbook -i 127.0.0.1, playbooks/cluster.yml
+        if [ ${#DOCKERHUB_USERNAME} != 0 ] && [ ${#DOCKERHUB_TOKEN} != 0 ]; then
+            ansible-playbook -i 127.0.0.1, playbooks/cluster.yml -e "DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME DOCKERHUB_TOKEN=$DOCKERHUB_TOKEN"
+        else
+            ansible-playbook -i 127.0.0.1, playbooks/cluster.yml
+        fi
     else
-        ansible-playbook -vvv -i 127.0.0.1, playbooks/cluster.yml
+        if [ ${#DOCKERHUB_USERNAME} != 0 ] && [ ${#DOCKERHUB_TOKEN} != 0 ]; then
+            ansible-playbook -vvv -i 127.0.0.1, playbooks/cluster.yml -e "DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME DOCKERHUB_TOKEN=$DOCKERHUB_TOKEN"
+        else
+            ansible-playbook -vvv -i 127.0.0.1, playbooks/cluster.yml
+        fi
     fi
 fi
 

--- a/e2e/provision/install_sandbox.sh
+++ b/e2e/provision/install_sandbox.sh
@@ -89,17 +89,9 @@ if [ "${DEPLOYMENT_TYPE:-r1}" == "one-summit" ]; then
 else
     # Management cluster creation
     if [[ ${DEBUG:-false} != "true" ]]; then
-        if [ ${#DOCKERHUB_USERNAME} != 0 ] && [ ${#DOCKERHUB_TOKEN} != 0 ]; then
-            ansible-playbook -i 127.0.0.1, playbooks/cluster.yml -e "DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME DOCKERHUB_TOKEN=$DOCKERHUB_TOKEN"
-        else
-            ansible-playbook -i 127.0.0.1, playbooks/cluster.yml
-        fi
+        ansible-playbook -i 127.0.0.1, playbooks/cluster.yml
     else
-        if [ ${#DOCKERHUB_USERNAME} != 0 ] && [ ${#DOCKERHUB_TOKEN} != 0 ]; then
-            ansible-playbook -vvv -i 127.0.0.1, playbooks/cluster.yml -e "DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME DOCKERHUB_TOKEN=$DOCKERHUB_TOKEN"
-        else
-            ansible-playbook -vvv -i 127.0.0.1, playbooks/cluster.yml
-        fi
+        ansible-playbook -vvv -i 127.0.0.1, playbooks/cluster.yml
     fi
 fi
 

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/prep-gitea.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/prep-gitea.yml
@@ -27,7 +27,10 @@
     token: "{{ lookup('ansible.builtin.env', 'DOCKERHUB_TOKEN') }}"
   block:
     - name: Create docker-registry secret
-      ansible.builtin.shell: kubectl create secret docker-registry dockerhub --docker-username={{ username }} --docker-password={{ token }} -n {{ gitea.k8s.namespace }}
+      ansible.builtin.command: >
+        kubectl create secret docker-registry dockerhub --docker-username={{ username }}
+        --docker-password={{ token }} -n {{ gitea.k8s.namespace }}
+      changed_when: false
     - name: Create docker-registry service account
       no_log: true
       kubernetes.core.k8s:

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/prep-gitea.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/prep-gitea.yml
@@ -20,11 +20,14 @@
 
 - name: Create docker hub secret
   when:
-    - DOCKERHUB_USERNAME is defined
-    - DOCKERHUB_TOKEN is defined
+    - lookup('ansible.builtin.env', 'DOCKERHUB_USERNAME') | length > 0
+    - lookup('ansible.builtin.env', 'DOCKERHUB_TOKEN') | length > 0
+  vars:
+    username: "{{ lookup('ansible.builtin.env', 'DOCKERHUB_USERNAME') }}"
+    token: "{{ lookup('ansible.builtin.env', 'DOCKERHUB_TOKEN') }}"
   block:
     - name: Create docker-registry secret
-      ansible.builtin.shell: kubectl create secret docker-registry dockerhub --docker-username={{ DOCKERHUB_USERNAME }} --docker-password={{ DOCKERHUB_TOKEN }} -n {{ gitea.k8s.namespace }}
+      ansible.builtin.shell: kubectl create secret docker-registry dockerhub --docker-username={{ username }} --docker-password={{ token }} -n {{ gitea.k8s.namespace }}
     - name: Create docker-registry service account
       no_log: true
       kubernetes.core.k8s:

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/prep-gitea.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/prep-gitea.yml
@@ -18,6 +18,27 @@
       metadata:
         name: "{{ gitea.k8s.namespace }}"
 
+- name: Create docker hub secret
+  when:
+    - DOCKERHUB_USERNAME is defined
+    - DOCKERHUB_TOKEN is defined
+  block:
+    - name: Create docker-registry secret
+      ansible.builtin.shell: kubectl create secret docker-registry dockerhub --docker-username={{ DOCKERHUB_USERNAME }} --docker-password={{ DOCKERHUB_TOKEN }} -n {{ gitea.k8s.namespace }}
+    - name: Create docker-registry service account
+      no_log: true
+      kubernetes.core.k8s:
+        context: "{{ k8s.context }}"
+        state: present
+        definition:
+          apiVersion: v1
+          kind: ServiceAccount
+          imagePullSecrets:
+            - name: dockerhub
+          metadata:
+            name: default
+            namespace: "{{ gitea.k8s.namespace }}"
+
 - name: Create gitea postgresql user password
   kubernetes.core.k8s:
     context: "{{ k8s.context }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR is a follow on to https://github.com/nephio-project/test-infra/pull/182 and a)relies on environment variable look up rather than pass them as extra-args to an ansible playbook b)uses the ansible.builtin.command instead of ansible.builtin.shell that allows for ansible-lint checks to pass

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
