### PR TITLE
Enable tox linter in provision folder

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -14,6 +14,21 @@ presubmits:
           args:
             - "--plugin-config=prow/config/plugins.yaml"
             - "--config-path=prow/config/config.yaml"
+  - name: provision-linter
+    annotations:
+    labels:
+    run_if_changed: '^e2e/provision'
+    skip_report: false
+    decorate: true
+    cluster: default
+    spec:
+      containers:
+        - image: "nephio/linter:1"
+          command:
+            - "/bin/sh"
+          args:
+            - "-c"
+            - set -eE; cd e2e/provision; /usr/local/bin/tox -e lint
   - name: e2e-ubuntu-focal
     annotations:
     labels:

--- a/images/linter/Dockerfile
+++ b/images/linter/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.11-slim
+
+RUN pip install --no-cache-dir tox==4.11.3


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
There are some linting rules which need to be applied to the `e2e/provision` folder every time that a new change is detected on that folder. This change provides a prow job to achive that.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
The `nephio/linter:1` docker image needs to be published before merging this patch.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
