### PR TITLE
Expose WebUI port thru Vagrant

### DIFF
--- a/e2e/provision/Vagrantfile
+++ b/e2e/provision/Vagrantfile
@@ -28,7 +28,7 @@ Vagrant.configure('2') do |config|
   config.vm.box_check_update = false
   config.vm.synced_folder "#{vagrant_root}/../../", '/opt/test-infra'
 
-  config.vm.network 'forwarded_port', guest: 7007, guest_ip: '127.0.0.1', host: 7007
+  config.vm.network 'forwarded_port', guest: 7007, guest_ip: '172.18.0.201', host: 7007
   config.vm.network 'forwarded_port', guest: 3000, guest_ip: '172.18.0.200', host: 3000
 
   # Upgrade Kernel version


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This change provides a way to export Nephio WebUI port to the host machine.

Depends-on: https://github.com/nephio-project/nephio-packages/pull/32

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/nephio-project/nephio/issues/258

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Expose Nephio WebUI service to the host machine 
```
