### PR TITLE
Fix for molecule image build

### DIFF
--- a/images/molecule/Dockerfile
+++ b/images/molecule/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 ENV USER molecule
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  openssh-client=1:9.2p1-2 \
+  openssh-client=1:9.2p1-2+deb12u1 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && pip install --no-cache-dir tox==4.11.3


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Molecule image build is failing on pinned openssh-clients version typo
```
E: Version '1:9.2p1-2' for 'openssh-client' was not found
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
