### PR TITLE
Fix permissions during molecule execution

### DIFF
--- a/images/molecule/Dockerfile
+++ b/images/molecule/Dockerfile
@@ -7,6 +7,3 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && pip install --no-cache-dir tox==4.11.3
-
-RUN useradd -ms /bin/bash $USER
-USER $USER


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Prow seems to mount and execute jobs with `root` user, using a different one causes `Permission denied` [errors](http://prow.nephio.io/view/gs/prow-nephio-sig-release/pr-logs/pull/nephio-project_test-infra/186/bootstrap-integration/1712572612661481472). This change removes the `molecule` user creation

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This container image has not been used by prow jobs yet.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
