### PR TITLE
Fix python version in e2e image

### DIFF
--- a/images/e2e/Dockerfile
+++ b/images/e2e/Dockerfile
@@ -2,5 +2,5 @@ FROM hashicorp/terraform:1.5.7
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN wget -q -c https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-446.0.0-linux-x86_64.tar.gz -O - | tar -xz -C /tmp && \
-    apk add --no-cache python3=3.11.5-r0 && \
+    apk add --no-cache python3 && \
     /tmp/google-cloud-sdk/install.sh -q

--- a/images/e2e/Dockerfile
+++ b/images/e2e/Dockerfile
@@ -2,5 +2,5 @@ FROM hashicorp/terraform:1.5.7
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN wget -q -c https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-446.0.0-linux-x86_64.tar.gz -O - | tar -xz -C /tmp && \
-    apk add --no-cache python3 && \
+    apk add --no-cache python3=3.11.6-r0 && \
     /tmp/google-cloud-sdk/install.sh -q


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
In the mean time python version in 'world' changed and pinned version causes image build to fail

```
ERROR: unable to select packages:
  python3-3.11.6-r0:
    breaks: world[python3=3.11.5-r0]
    satisfies: python3-3.11.6-r0[python3~3.11]
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://prow.nephio.io/view/gs/prow-nephio-sig-release/logs/build-push-image-e2e/1714586107494010880
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
