### PR TITLE
Add extra_refs in prow periodic jobs

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1522,6 +1522,10 @@ periodics:
     skip_report: false
     decorate: true
     cluster: default
+    extra_refs:
+      - org: nephio-project
+        repo: test-infra
+        base_ref: main
     spec:
       containers:
         - image: "nephio/e2e:latest"
@@ -1572,6 +1576,10 @@ periodics:
     skip_report: false
     decorate: true
     cluster: default
+    extra_refs:
+      - org: nephio-project
+        repo: test-infra
+        base_ref: main
     spec:
       containers:
         - image: "nephio/e2e:latest"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Apparently Prow periodic jobs do not clone any repo by default, so it's necessary to specify the repositories to be used. This change fixes the periodic prow definition.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Once this is merged, it's necessary to see the results in the [dashboard](http://prow.nephio.io/?type=periodic)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
