### PR TITLE
Adding path alias in extra_refs and changing execution path 

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1526,6 +1526,7 @@ periodics:
       - org: nephio-project
         repo: test-infra
         base_ref: main
+        path_alias: nephio_repo/test-infra
     spec:
       containers:
         - image: "nephio/e2e:latest"
@@ -1534,7 +1535,7 @@ periodics:
           args:
             - "-c"
             - |
-              set -eE; cd "$(git rev-parse --show-toplevel)/e2e/terraform"; trap 'terraform destroy -target module.gcp-ubuntu-focal -auto-approve' EXIT;
+              set -eE; cd "$GOPATH/src/nephio_repo/test-infra/e2e/terraform"; trap 'terraform destroy -target module.gcp-ubuntu-focal -auto-approve' EXIT;
               terraform init && timeout 75m terraform apply -target module.gcp-ubuntu-focal -auto-approve
           volumeMounts:
             - name: satoken
@@ -1580,6 +1581,7 @@ periodics:
       - org: nephio-project
         repo: test-infra
         base_ref: main
+        path_alias: nephio_repo/test-infra
     spec:
       containers:
         - image: "nephio/e2e:latest"
@@ -1588,7 +1590,7 @@ periodics:
           args:
             - "-c"
             - |
-              set -eE; cd "$(git rev-parse --show-toplevel)/e2e/terraform"; trap 'terraform destroy -target module.gcp-fedora-34 -auto-approve' EXIT;
+              set -eE; cd "$GOPATH/src/nephio_repo/test-infra/e2e/terraform"; trap 'terraform destroy -target module.gcp-fedora-34 -auto-approve' EXIT;
               terraform init && timeout 75m terraform apply -target module.gcp-fedora-34 -auto-approve
           volumeMounts:
             - name: satoken


### PR DESCRIPTION
Adding path alias in extra_refs and changing execution path in e2e periodics

<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Periodic jobs doesn't checkout anything by default, extra_refs will do that so the execution path should be different
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
