### PR TITLE
Pass HTTP proxy environment variables to the Docker daemon 

### DIFF
--- a/e2e/provision/playbooks/cluster.yml
+++ b/e2e/provision/playbooks/cluster.yml
@@ -15,13 +15,14 @@
     clab:
       version: 0.42.0
       download_url: "https://github.com/srl-labs/containerlab/releases/download"
-  environment:
-    http_proxy: "{{ lookup('ansible.builtin.env', 'http_proxy') | default(omit) }}"
-    HTTP_PROXY: "{{ lookup('ansible.builtin.env', 'HTTP_PROXY') | default(omit) }}"
-    https_proxy: "{{ lookup('ansible.builtin.env', 'https_proxy') | default(omit) }}"
-    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'HTTPS_PROXY') | default(omit) }}"
-    no_proxy: "{{ lookup('ansible.builtin.env', 'no_proxy') | default(omit) }}"
-    NO_PROXY: "{{ lookup('ansible.builtin.env', 'NO_PROXY') | default(omit) }}"
+    proxy_env:
+      http_proxy: "{{ lookup('ansible.builtin.env', 'http_proxy') }}"
+      https_proxy: "{{ lookup('ansible.builtin.env', 'https_proxy') }}"
+      no_proxy: "{{ lookup('ansible.builtin.env', 'no_proxy') }}"
+      HTTP_PROXY: "{{ lookup('ansible.builtin.env', 'HTTP_PROXY') }}"
+      HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'HTTPS_PROXY') }}"
+      NO_PROXY: "{{ lookup('ansible.builtin.env', 'NO_PROXY') }}"
+  environment: "{{ proxy_env | dict2items | selectattr('value') | items2dict }}"
 
   pre_tasks:
     - name: "Print environment variable-based configuration"
@@ -53,12 +54,12 @@
         - name: Pass HTTP proxy parameters to the Docker daemon
           ansible.builtin.set_fact:
             docker_engine_init_exports:
-              http_proxy: "{{ lookup('ansible.builtin.env', 'http_proxy') | default(omit) }}"
-              HTTP_PROXY: "{{ lookup('ansible.builtin.env', 'HTTP_PROXY') | default(omit) }}"
-              https_proxy: "{{ lookup('ansible.builtin.env', 'https_proxy') | default(omit) }}"
-              HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'HTTPS_PROXY') | default(omit) }}"
-              no_proxy: "{{ lookup('ansible.builtin.env', 'no_proxy') | default(omit) }}"
-              NO_PROXY: "{{ lookup('ansible.builtin.env', 'NO_PROXY') | default(omit) }}"
+              http_proxy: "{{ lookup('ansible.builtin.env', 'http_proxy', default=omit) }}"
+              HTTP_PROXY: "{{ lookup('ansible.builtin.env', 'HTTP_PROXY', default=omit) }}"
+              https_proxy: "{{ lookup('ansible.builtin.env', 'https_proxy', default=omit) }}"
+              HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'HTTPS_PROXY', default=omit) }}"
+              no_proxy: "{{ lookup('ansible.builtin.env', 'no_proxy', default=omit) }}"
+              NO_PROXY: "{{ lookup('ansible.builtin.env', 'NO_PROXY', default=omit) }}"
 
         - name: Install docker binaries
           ansible.builtin.include_role:

--- a/e2e/provision/playbooks/cluster.yml
+++ b/e2e/provision/playbooks/cluster.yml
@@ -15,7 +15,27 @@
     clab:
       version: 0.42.0
       download_url: "https://github.com/srl-labs/containerlab/releases/download"
+  environment:
+    http_proxy: "{{ lookup('ansible.builtin.env', 'http_proxy') | default(omit) }}"
+    HTTP_PROXY: "{{ lookup('ansible.builtin.env', 'HTTP_PROXY') | default(omit) }}"
+    https_proxy: "{{ lookup('ansible.builtin.env', 'https_proxy') | default(omit) }}"
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'HTTPS_PROXY') | default(omit) }}"
+    no_proxy: "{{ lookup('ansible.builtin.env', 'no_proxy') | default(omit) }}"
+    NO_PROXY: "{{ lookup('ansible.builtin.env', 'NO_PROXY') | default(omit) }}"
+
   pre_tasks:
+    - name: "Print environment variable-based configuration"
+      become: true
+      ansible.builtin.debug:
+        msg:
+          - "DOCKERHUB_USERNAME: {{ lookup('ansible.builtin.env', 'DOCKERHUB_USERNAME') }}"
+          - "DOCKERHUB_TOKEN: {{ lookup('ansible.builtin.env', 'DOCKERHUB_TOKEN') }}"
+          - "DOCKER_REGISTRY_MIRRORS: {{ lookup('ansible.builtin.env', 'DOCKER_REGISTRY_MIRRORS') }}"
+          - "HTTP_PROXY: {{ lookup('ansible.builtin.env', 'HTTP_PROXY') }}, HTTPS_PROXY: {{ lookup('ansible.builtin.env', 'HTTPS_PROXY') }}"
+          - "NO_PROXY: {{ lookup('ansible.builtin.env', 'NO_PROXY') }}"
+          - "http_proxy: {{ lookup('ansible.builtin.env', 'http_proxy') }}, https_proxy: {{ lookup('ansible.builtin.env', 'https_proxy') }}"
+          - "no_proxy: {{ lookup('ansible.builtin.env', 'no_proxy') }}"
+
     - name: Install kubernetes python package
       become: true
       ansible.builtin.pip:
@@ -29,6 +49,16 @@
             docker_engine_daemon_json:
               registry-mirrors: "{{ lookup('ansible.builtin.env', 'DOCKER_REGISTRY_MIRRORS') }}"
           when: lookup('ansible.builtin.env', 'DOCKER_REGISTRY_MIRRORS')
+
+        - name: Pass HTTP proxy parameters to the Docker daemon
+          ansible.builtin.set_fact:
+            docker_engine_init_exports:
+              http_proxy: "{{ lookup('ansible.builtin.env', 'http_proxy') | default(omit) }}"
+              HTTP_PROXY: "{{ lookup('ansible.builtin.env', 'HTTP_PROXY') | default(omit) }}"
+              https_proxy: "{{ lookup('ansible.builtin.env', 'https_proxy') | default(omit) }}"
+              HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'HTTPS_PROXY') | default(omit) }}"
+              no_proxy: "{{ lookup('ansible.builtin.env', 'no_proxy') | default(omit) }}"
+              NO_PROXY: "{{ lookup('ansible.builtin.env', 'NO_PROXY') | default(omit) }}"
 
         - name: Install docker binaries
           ansible.builtin.include_role:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

This passes the HTTP proxy environment variables set in the host environment that runs the ansible playbook to the newly installed Docker daemon and to the tasks of the ansible playbook itself.

**Which issue(s) this PR fixes**:

It is a step toward fixing https://github.com/nephio-project/nephio/issues/409 , but it will not completely fix the issue.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
