### PR TITLE
Enable 002 OAI End-to-End test

### DIFF
--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -26,7 +26,7 @@ test_summary=""
 for t in $TESTDIR/*.sh; do
     if ! run_test "$t"; then
         failed=$((failed + 1))
-        [[ ${FAIL_FAST:-false} != "true" ]] ||  break
+        [[ ${FAIL_FAST:-false} != "true" ]] || break
     fi
 done
 echo "TEST SUMMARY"

--- a/e2e/provision/Vagrantfile
+++ b/e2e/provision/Vagrantfile
@@ -16,6 +16,7 @@ vagrant_root = File.dirname(__FILE__)
 vagrant_boxes = YAML.load_file("#{vagrant_root}/distros_supported.yml")
 os_distro = ENV['OS_DISTRO'] || 'ubuntu_focal'
 box = vagrant_boxes[os_distro]
+num_sandboxes = ENV['NUM_SANDBOXES'] || '1'
 
 # rubocop:disable Metrics/BlockLength
 Vagrant.configure('2') do |config|
@@ -24,6 +25,11 @@ Vagrant.configure('2') do |config|
   config.vm.provider :virtualbox
   config.vm.provider :google
 
+  (1..num_sandboxes.to_i).each do |i|
+    config.vm.define "sandbox#{i.to_s.rjust(2, '0')}" do |nodeconfig|
+      nodeconfig.vm.hostname = "sandbox#{i.to_s.rjust(2, '0')}"
+    end
+  end
   config.vm.box = box['name']
   config.vm.box_check_update = false
   config.vm.synced_folder "#{vagrant_root}/../../", '/opt/test-infra'

--- a/e2e/provision/playbooks/roles/install/defaults/main.yml
+++ b/e2e/provision/playbooks/roles/install/defaults/main.yml
@@ -31,7 +31,7 @@ nephio_stock_repos:
     branch: main
   - name: oai-packages
     repo: https://github.com/OPENAIRINTERFACE/oai-packages.git
-    branch: main
+    branch: r2
 
 nephio:
   k8s:

--- a/e2e/tests/oai/002-oai-operators.yaml
+++ b/e2e/tests/oai/002-oai-operators.yaml
@@ -1,0 +1,66 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+apiVersion: config.porch.kpt.dev/v1alpha2
+kind: PackageVariantSet
+metadata:
+  name: oai-common
+spec:
+  upstream:
+    repo: oai-packages
+    package: database
+    revision: r2
+  targets:
+  - objectSelector:
+      apiVersion: infra.nephio.org/v1alpha1
+      kind: WorkloadCluster
+      matchLabels:
+        nephio.org/site-type: regional
+    template:
+      downstream:
+        package: database
+      annotations:
+        approval.nephio.org/policy: initial
+      injectors:
+      - nameExpr: target.name
+---
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: oai-cp-operators
+spec:
+  upstream:
+    repo: oai-packages
+    package: oai-cp-operators
+    revision: r2
+  downstream:
+    repo: regional
+    package: oai-cp-operators
+  annotations:
+    approval.nephio.org/policy: initial
+  injectors:
+  - name: regional
+---
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: oai-up-operators
+spec:
+  upstream:
+    repo: oai-packages
+    package: oai-up-operators
+    revision: r2
+  downstream:
+    repo: edge
+    package: oai-up-operators
+  annotations:
+    approval.nephio.org/policy: initial
+  injectors:
+  - name: edge

--- a/e2e/tests/oai/002.sh
+++ b/e2e/tests/oai/002.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#!/usr/bin/env bash
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+## TEST METADATA
+## TEST-NAME: Deploy OAI Core Operators
+##
+
+set -o pipefail
+set -o errexit
+set -o nounset
+[[ ${DEBUG:-false} != "true" ]] || set -o xtrace
+
+# shellcheck source=e2e/defaults.env
+source "$E2EDIR/defaults.env"
+
+# shellcheck source=e2e/lib/k8s.sh
+source "${LIBDIR}/k8s.sh"
+
+# shellcheck source=e2e/lib/kpt.sh
+source "${LIBDIR}/kpt.sh"
+
+k8s_apply "$TESTDIR/002-oai-operators.yaml"
+
+for pkgvar in common-regional-database cp-operators up-operators; do
+    k8s_wait_ready "packagevariant" "oai-$pkgvar"
+done
+kpt_wait_pkg "regional" "database"
+kpt_wait_pkg "regional" "oai-cp-operators"
+kpt_wait_pkg "edge" "oai-up-operators"
+
+_regional_kubeconfig="$(k8s_get_capi_kubeconfig "regional")"
+k8s_wait_ready_replicas "deployment" "mysql" "$_regional_kubeconfig" "oai-core"
+for controller in amf ausf nrf smf udm udr; do
+    k8s_wait_ready_replicas "deployment" "oai-$controller-controller" "$_regional_kubeconfig" "oai-operators"
+done
+k8s_wait_ready_replicas "deployment" "oai-upf-controller" "$(k8s_get_capi_kubeconfig "edge")" "oai-operators"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This change provides the resources to deploy OAI controllers. It validates the creation of `packagevariant` and `deployment` resources

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
It requires using the E2ETYPE env to `oai` value

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Deploy OAI controllers in regional and edge clusters
```
