### PR TITLE
Small improvements on e2e scripts

### DIFF
--- a/e2e/tests/free5gc/002.sh
+++ b/e2e/tests/free5gc/002.sh
@@ -60,5 +60,10 @@ k8s_apply "$TESTDIR/002-secret.yaml"
 k8s_wait_ready "packagevariant" "network"
 kpt_wait_pkg "mgmt" "network"
 
+# Wait for cluster resources creation
+for vpc in internal internet ran; do
+    k8s_wait_exists "networkinstance" "vpc-$vpc"
+done
+
 # Generate a RawTopology to interconnect clusters
 "$E2EDIR/provision/hacks/network-topo.sh"

--- a/e2e/tests/oai/001.sh
+++ b/e2e/tests/oai/001.sh
@@ -108,5 +108,10 @@ k8s_apply "$TESTDIR/001-secret.yaml"
 k8s_wait_ready "packagevariant" "network"
 kpt_wait_pkg "mgmt" "network"
 
+# Wait for cluster resources creation
+for vpc in cu-e1 cudu-f1 internal internet ran; do
+    k8s_wait_exists "networkinstance" "vpc-$vpc"
+done
+
 # Generate a RawTopology to interconnect clusters
 "$E2EDIR/provision/hacks/network-topo.sh"

--- a/e2e/tests/oai/clab-topo.gotmpl
+++ b/e2e/tests/oai/clab-topo.gotmpl
@@ -8,7 +8,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 ##############################################################################
 
-name: r2-network
+name: 5g
 prefix: net
 mgmt:
   network: kind


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
The OAI containerlab network name doesn't match with the name used by free5gc. This could result in connectivity issues. As improvement, it was included a waiting process for Network instance resources.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
