### PR TITLE
Enable `fail fast` CI feature to reduce the End-to-End testing consumption

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -135,7 +135,7 @@ presubmits:
             - "-c"
             - |
               set -eE; cd "$(git rev-parse --show-toplevel)/e2e/terraform"; trap 'terraform destroy -target module.gcp-ubuntu-focal -auto-approve' EXIT;
-              terraform init && timeout 75m terraform apply -target module.gcp-ubuntu-focal -var="pkg_version=v1.0.1" -auto-approve
+              terraform init && timeout 75m terraform apply -target module.gcp-ubuntu-focal -var="fail_fast=true" -auto-approve
           volumeMounts:
             - name: satoken
               mountPath: "/etc/satoken"
@@ -186,7 +186,7 @@ presubmits:
             - "-c"
             - |
               set -eE; cd "$(git rev-parse --show-toplevel)/e2e/terraform"; trap 'terraform destroy -target module.gcp-fedora-34 -auto-approve' EXIT;
-              terraform init && timeout 75m terraform apply -target module.gcp-fedora-34 -var="pkg_version=v1.0.1" -auto-approve
+              terraform init && timeout 75m terraform apply -target module.gcp-fedora-34 -var="fail_fast=true" -auto-approve
           volumeMounts:
             - name: satoken
               mountPath: "/etc/satoken"
@@ -236,7 +236,7 @@ presubmits:
             - "-c"
             - |
               set -eE; cd "$(git rev-parse --show-toplevel)/e2e/terraform"; trap 'terraform destroy -target module.gcp-ubuntu-jammy -auto-approve' EXIT;
-              terraform init && timeout 75m terraform apply -target module.gcp-ubuntu-jammy -var="pkg_version=v1.0.1" -var="e2e_type=oai" -auto-approve
+              terraform init && timeout 75m terraform apply -target module.gcp-ubuntu-jammy -var="e2e_type=oai" -var="fail_fast=true" -auto-approve
           volumeMounts:
             - name: satoken
               mountPath: "/etc/satoken"

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -135,7 +135,7 @@ presubmits:
             - "-c"
             - |
               set -eE; cd "$(git rev-parse --show-toplevel)/e2e/terraform"; trap 'terraform destroy -target module.gcp-ubuntu-focal -auto-approve' EXIT;
-              terraform init && timeout 75m terraform apply -target module.gcp-ubuntu-focal -var="fail_fast=true" -auto-approve
+              terraform init && timeout 120m terraform apply -target module.gcp-ubuntu-focal -var="fail_fast=true" -auto-approve
           volumeMounts:
             - name: satoken
               mountPath: "/etc/satoken"
@@ -186,7 +186,7 @@ presubmits:
             - "-c"
             - |
               set -eE; cd "$(git rev-parse --show-toplevel)/e2e/terraform"; trap 'terraform destroy -target module.gcp-fedora-34 -auto-approve' EXIT;
-              terraform init && timeout 75m terraform apply -target module.gcp-fedora-34 -var="fail_fast=true" -auto-approve
+              terraform init && timeout 120m terraform apply -target module.gcp-fedora-34 -var="fail_fast=true" -auto-approve
           volumeMounts:
             - name: satoken
               mountPath: "/etc/satoken"
@@ -236,7 +236,7 @@ presubmits:
             - "-c"
             - |
               set -eE; cd "$(git rev-parse --show-toplevel)/e2e/terraform"; trap 'terraform destroy -target module.gcp-ubuntu-jammy -auto-approve' EXIT;
-              terraform init && timeout 75m terraform apply -target module.gcp-ubuntu-jammy -var="e2e_type=oai" -var="fail_fast=true" -auto-approve
+              terraform init && timeout 120m terraform apply -target module.gcp-ubuntu-jammy -var="e2e_type=oai" -var="fail_fast=true" -auto-approve
           volumeMounts:
             - name: satoken
               mountPath: "/etc/satoken"

--- a/e2e/lib/kpt.sh
+++ b/e2e/lib/kpt.sh
@@ -41,9 +41,8 @@ function _wait_for_user_repo {
     if [[ $found != "True" ]]; then
         curl_gitea_api "users/$user/repos" 'import json; import sys; print("\n".join(repo["full_name"] for repo in json.loads(sys.stdin.read())))'
         error "Timed out waiting for $repo repository"
-    else
-        info "Found $user/$repo repository"
     fi
+    info "Found $user/$repo repository"
 }
 
 # kpt_wait_pkg() - Wait for a given kpt package to exist in a given repository
@@ -69,8 +68,6 @@ function kpt_wait_pkg {
     if [[ $found != "True" ]]; then
         curl_gitea_api "repos/$user/$repo/contents" 'import json; import sys; print("\n".join(dir["path"] for dir in json.loads(sys.stdin.read()) if dir["type"] == "dir" ))'
         error "Timed out waiting for $pkg kpt package"
-    else
-        info "Found $user/$repo repository"
     fi
-
+    info "Found $pkg kpt package in $user/$repo repository"
 }

--- a/e2e/provision/Vagrantfile
+++ b/e2e/provision/Vagrantfile
@@ -61,6 +61,7 @@ Vagrant.configure('2') do |config|
       NEPHIO_REPO_DIR: '/opt/test-infra',
       ANSIBLE_CMD_EXTRA_VAR_LIST: "k8s.context='kind-kind' nephio_catalog_repo_uri='#{ENV['NEPHIO_CATALOG_REPO_URI'] || 'https://github.com/nephio-project/nephio-catalog-packages.git'}'",
       E2EDIR: '/opt/test-infra/e2e',
+      FAIL_FAST: true,
       E2ETYPE: ENV.fetch('E2ETYPE', 'free5gc')
     }
     sh.inline = <<-SHELL

--- a/e2e/provision/init.sh
+++ b/e2e/provision/init.sh
@@ -64,6 +64,7 @@ HOME=${NEPHIO_HOME:-/home/$NEPHIO_USER}
 REPO_DIR=${NEPHIO_REPO_DIR:-$HOME/test-infra}
 DOCKERHUB_USERNAME=${DOCKERHUB_USERNAME:-""}
 DOCKERHUB_TOKEN=${DOCKERHUB_TOKEN:-""}
+FAIL_FAST=${FAIL_FAST:-$(get_metadata fail_fast "false")}
 
 echo "$DEBUG, $DEPLOYMENT_TYPE, $RUN_E2E, $REPO, $BRANCH, $NEPHIO_USER, $HOME, $REPO_DIR, $DOCKERHUB_USERNAME, $DOCKERHUB_TOKEN"
 trap get_status ERR
@@ -109,7 +110,7 @@ sed -e "s/vagrant/$NEPHIO_USER/" <"$REPO_DIR/e2e/provision/nephio.yaml" >"$HOME/
 # Sandbox Creation
 int_start=$(date +%s)
 cd "$REPO_DIR/e2e/provision"
-export DEBUG DEPLOYMENT_TYPE DOCKERHUB_USERNAME DOCKERHUB_TOKEN
+export DEBUG DEPLOYMENT_TYPE DOCKERHUB_USERNAME DOCKERHUB_TOKEN FAIL_FAST
 runuser -u "$NEPHIO_USER" ./install_sandbox.sh
 printf "%s secs\n" "$(($(date +%s) - int_start))"
 

--- a/e2e/provision/init.sh
+++ b/e2e/provision/init.sh
@@ -73,6 +73,8 @@ if ! command -v git >/dev/null; then
     source /etc/os-release || source /usr/lib/os-release
     case ${ID,,} in
     ubuntu | debian)
+        # Removed the damaged list
+        rm -rvf /var/lib/apt/lists/*
         apt-get update
         apt-get install -y git
         ;;

--- a/e2e/provision/install_sandbox.sh
+++ b/e2e/provision/install_sandbox.sh
@@ -19,6 +19,8 @@ export HOME=${HOME:-/home/ubuntu/}
 source /etc/os-release || source /usr/lib/os-release
 case ${ID,,} in
 ubuntu | debian)
+    # Removed the damaged list
+    sudo rm -vrf /var/lib/apt/lists/*
     sudo apt-get update
     sudo -E DEBIAN_FRONTEND=noninteractive apt-get remove -q -y python3-openssl
     sudo -E NEEDRESTART_SUSPEND=1 DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" --allow-downgrades --allow-remove-essential --allow-change-held-packages -fuy install -q -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" python3-pip

--- a/e2e/terraform/main.tf
+++ b/e2e/terraform/main.tf
@@ -1,22 +1,25 @@
 module "gcp-ubuntu-focal" {
-  source             = ".//modules/gcp"
-  nephio_pkg_version = var.pkg_version
-  nephio_e2e_type    = var.e2e_type
+  source               = ".//modules/gcp"
+  nephio_pkg_version   = var.pkg_version
+  nephio_e2e_type      = var.e2e_type
+  nephio_e2e_fail_fast = var.fail_fast
 }
 
 module "gcp-ubuntu-jammy" {
-  source             = ".//modules/gcp"
-  vmimage            = "ubuntu-os-cloud/ubuntu-2204-lts"
-  nephio_pkg_version = var.pkg_version
-  nephio_e2e_type    = var.e2e_type
+  source               = ".//modules/gcp"
+  vmimage              = "ubuntu-os-cloud/ubuntu-2204-lts"
+  nephio_pkg_version   = var.pkg_version
+  nephio_e2e_type      = var.e2e_type
+  nephio_e2e_fail_fast = var.fail_fast
 }
 
 module "gcp-fedora-34" {
-  source             = ".//modules/gcp"
-  vmimage            = "fedora-cloud/fedora-cloud-34"
-  ansible_user       = "fedora"
-  nephio_pkg_version = var.pkg_version
-  nephio_e2e_type    = var.e2e_type
+  source               = ".//modules/gcp"
+  vmimage              = "fedora-cloud/fedora-cloud-34"
+  ansible_user         = "fedora"
+  nephio_pkg_version   = var.pkg_version
+  nephio_e2e_type      = var.e2e_type
+  nephio_e2e_fail_fast = var.fail_fast
 }
 
 variable "pkg_version" {
@@ -28,5 +31,11 @@ variable "pkg_version" {
 variable "e2e_type" {
   description = "The End-to-End testing type"
   default     = "free5gc"
+  type        = string
+}
+
+variable "fail_fast" {
+  description = "Defines the behavior after failing a testing"
+  default     = "false"
   type        = string
 }

--- a/e2e/terraform/main.tf
+++ b/e2e/terraform/main.tf
@@ -1,6 +1,5 @@
 module "gcp-ubuntu-focal" {
   source               = ".//modules/gcp"
-  nephio_pkg_version   = var.pkg_version
   nephio_e2e_type      = var.e2e_type
   nephio_e2e_fail_fast = var.fail_fast
 }
@@ -8,7 +7,6 @@ module "gcp-ubuntu-focal" {
 module "gcp-ubuntu-jammy" {
   source               = ".//modules/gcp"
   vmimage              = "ubuntu-os-cloud/ubuntu-2204-lts"
-  nephio_pkg_version   = var.pkg_version
   nephio_e2e_type      = var.e2e_type
   nephio_e2e_fail_fast = var.fail_fast
 }
@@ -17,15 +15,8 @@ module "gcp-fedora-34" {
   source               = ".//modules/gcp"
   vmimage              = "fedora-cloud/fedora-cloud-34"
   ansible_user         = "fedora"
-  nephio_pkg_version   = var.pkg_version
   nephio_e2e_type      = var.e2e_type
   nephio_e2e_fail_fast = var.fail_fast
-}
-
-variable "pkg_version" {
-  description = "The version used for all the nephio packages"
-  default     = "main"
-  type        = string
 }
 
 variable "e2e_type" {

--- a/e2e/terraform/modules/gcp/main.tf
+++ b/e2e/terraform/modules/gcp/main.tf
@@ -112,7 +112,7 @@ resource "google_compute_instance" "e2e_instances" {
     inline = [
       "cd /home/${var.ansible_user}/test-infra/e2e/provision/",
       "chmod +x init.sh",
-      "sudo -E E2ETYPE=${var.nephio_e2e_type} NEPHIO_PKG_VERSION=${var.nephio_pkg_version} NEPHIO_REPO_DIR=/home/${var.ansible_user}/test-infra NEPHIO_DEBUG=true NEPHIO_RUN_E2E=true NEPHIO_USER=${var.ansible_user} ./init.sh"
+      "sudo -E FAIL_FAST=${var.nephio_e2e_fail_fast} E2ETYPE=${var.nephio_e2e_type} NEPHIO_PKG_VERSION=${var.nephio_pkg_version} NEPHIO_REPO_DIR=/home/${var.ansible_user}/test-infra NEPHIO_DEBUG=true NEPHIO_RUN_E2E=true NEPHIO_USER=${var.ansible_user} ./init.sh"
     ]
   }
 }

--- a/e2e/terraform/modules/gcp/main.tf
+++ b/e2e/terraform/modules/gcp/main.tf
@@ -112,7 +112,7 @@ resource "google_compute_instance" "e2e_instances" {
     inline = [
       "cd /home/${var.ansible_user}/test-infra/e2e/provision/",
       "chmod +x init.sh",
-      "sudo -E FAIL_FAST=${var.nephio_e2e_fail_fast} E2ETYPE=${var.nephio_e2e_type} NEPHIO_PKG_VERSION=${var.nephio_pkg_version} NEPHIO_REPO_DIR=/home/${var.ansible_user}/test-infra NEPHIO_DEBUG=true NEPHIO_RUN_E2E=true NEPHIO_USER=${var.ansible_user} ./init.sh"
+      "sudo -E FAIL_FAST=${var.nephio_e2e_fail_fast} E2ETYPE=${var.nephio_e2e_type} NEPHIO_REPO_DIR=/home/${var.ansible_user}/test-infra NEPHIO_DEBUG=true NEPHIO_RUN_E2E=true NEPHIO_USER=${var.ansible_user} ./init.sh"
     ]
   }
 }

--- a/e2e/terraform/modules/gcp/variables.tf
+++ b/e2e/terraform/modules/gcp/variables.tf
@@ -64,12 +64,6 @@ variable "nephio_e2e_nodes" {
   type        = number
 }
 
-variable "nephio_pkg_version" {
-  description = "The version used for all the nephio packages"
-  default     = "main"
-  type        = string
-}
-
 variable "nephio_e2e_type" {
   description = "The Nephio End-to-End testing type"
   default     = "free5gc"

--- a/e2e/terraform/modules/gcp/variables.tf
+++ b/e2e/terraform/modules/gcp/variables.tf
@@ -75,3 +75,9 @@ variable "nephio_e2e_type" {
   default     = "free5gc"
   type        = string
 }
+
+variable "nephio_e2e_fail_fast" {
+  description = "The Nephio End-to-End testing failing behavior"
+  default     = "false"
+  type        = string
+}

--- a/e2e/tests/free5gc/004.sh
+++ b/e2e/tests/free5gc/004.sh
@@ -24,8 +24,18 @@ source "$E2EDIR/defaults.env"
 # shellcheck source=e2e/lib/k8s.sh
 source "${LIBDIR}/k8s.sh"
 
+# shellcheck source=e2e/lib/kpt.sh
+source "${LIBDIR}/kpt.sh"
+
+# shellcheck source=e2e/lib/porch.sh
+source "${LIBDIR}/porch.sh"
+
 k8s_apply "$TESTDIR/004-free5gc-operator.yaml"
 
-for cluster in "regional" "edge01" "edge02"; do
+kubeconfig="$HOME/.kube/config"
+for cluster in $(kubectl get cl -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' --kubeconfig "$kubeconfig"); do
+    k8s_wait_exists "packagevariant" "free5gc-operator-$cluster-free5gc-operator"
+    porch_wait_log_entry "refs/heads/proposed/free5gc-operator/packagevariant-1 :refs/heads/drafts/free5gc-operator/packagevariant-1"
+    kpt_wait_pkg "$cluster" "free5gc-operator"
     k8s_wait_ready_replicas "deployment" "free5gc-operator" "$(k8s_get_capi_kubeconfig "$cluster")" "free5gc"
 done

--- a/e2e/tests/free5gc/005.sh
+++ b/e2e/tests/free5gc/005.sh
@@ -31,5 +31,5 @@ for cluster in "edge01" "edge02"; do
 done
 
 for cluster in "edge01" "edge02"; do
-    k8s_wait_ready_replicas "deployment" "upf-${cluster}" "$(k8s_get_capi_kubeconfig "$cluster")" "free5gc-upf"
+    k8s_wait_ready_replicas "deployment" "upf-${cluster}" "$(k8s_get_capi_kubeconfig "$cluster")" "free5gc-upf" "900"
 done

--- a/e2e/tests/oai/004-ran-network.sh
+++ b/e2e/tests/oai/004-ran-network.sh
@@ -36,16 +36,19 @@ function _wait_for_ran {
     timeout=600
 
     temp_file=$(mktemp)
-    kubectl logs "$(kubectl get pods -n oai-ran-cucp --kubeconfig "$kubeconfig" -l app.kubernetes.io/name=oai-gnb-cu-cp -o jsonpath='{.items[*].metadata.name}')" -n oai-ran-cucp -c gnbcucp --kubeconfig "$kubeconfig" > temp_file
-    while grep -q "$wait_msg" temp_file;status=$?; [[ $status != 0 ]]
-    	do
-        	if [[ $timeout -lt 0 ]]; then
-            		kubectl logs -l app.kubernetes.io/name=oai-gnb-cu-cp -n oai-ran-cucp -c gnbcucp --kubeconfig "$kubeconfig" --tail 50
-            		error "Timed out waiting for $link_name link to be established"
-        	fi
-        	timeout=$((timeout - 5))
-        	sleep 5
-		kubectl logs "$(kubectl get pods -n oai-ran-cucp --kubeconfig "$kubeconfig" -l app.kubernetes.io/name=oai-gnb-cu-cp -o jsonpath='{.items[*].metadata.name}')" -n oai-ran-cucp -c gnbcucp --kubeconfig "$kubeconfig" > temp_file
+    kubectl logs "$(kubectl get pods -n oai-ran-cucp --kubeconfig "$kubeconfig" -l app.kubernetes.io/name=oai-gnb-cu-cp -o jsonpath='{.items[*].metadata.name}')" -n oai-ran-cucp -c gnbcucp --kubeconfig "$kubeconfig" >temp_file
+    while
+        grep -q "$wait_msg" temp_file
+        status=$?
+        [[ $status != 0 ]]
+    do
+        if [[ $timeout -lt 0 ]]; then
+            kubectl logs -l app.kubernetes.io/name=oai-gnb-cu-cp -n oai-ran-cucp -c gnbcucp --kubeconfig "$kubeconfig" --tail 50
+            error "Timed out waiting for $link_name link to be established"
+        fi
+        timeout=$((timeout - 5))
+        sleep 5
+        kubectl logs "$(kubectl get pods -n oai-ran-cucp --kubeconfig "$kubeconfig" -l app.kubernetes.io/name=oai-gnb-cu-cp -o jsonpath='{.items[*].metadata.name}')" -n oai-ran-cucp -c gnbcucp --kubeconfig "$kubeconfig" >temp_file
     done
     debug "timeout: $timeout"
     rm "${temp_file}"

--- a/e2e/tests/oai/005-ue.sh
+++ b/e2e/tests/oai/005-ue.sh
@@ -35,16 +35,19 @@ function _wait_for_ue {
     info "waiting for $msg to be finished"
     timeout=600
     temp_file=$(mktemp)
-    kubectl logs "$(kubectl get pods -n oai-ue --kubeconfig "$kubeconfig" -l app.kubernetes.io/name=oai-nr-ue -o jsonpath='{.items[*].metadata.name}')" -n oai-ue -c nr-ue --kubeconfig "$kubeconfig" > temp_file
-    while grep -q "$log_msg" temp_file;status=$?; [ $status != 0 ]
-    	do
-        	if [[ $timeout -lt 0 ]]; then
-            		kubectl logs -l app.kubernetes.io/name=oai-nr-ue -n oai-ue -c nr-ue --kubeconfig "$kubeconfig" --tail 50
-            		error "Timed out waiting for $msg"
-        	fi
-        	timeout=$((timeout - 5))
-        	sleep 5
-		kubectl logs "$(kubectl get pods -n oai-ue --kubeconfig "$kubeconfig" -l app.kubernetes.io/name=oai-nr-ue -o jsonpath='{.items[*].metadata.name}')" -n oai-ue -c nr-ue --kubeconfig "$kubeconfig" > temp_file
+    kubectl logs "$(kubectl get pods -n oai-ue --kubeconfig "$kubeconfig" -l app.kubernetes.io/name=oai-nr-ue -o jsonpath='{.items[*].metadata.name}')" -n oai-ue -c nr-ue --kubeconfig "$kubeconfig" >temp_file
+    while
+        grep -q "$log_msg" temp_file
+        status=$?
+        [ $status != 0 ]
+    do
+        if [[ $timeout -lt 0 ]]; then
+            kubectl logs -l app.kubernetes.io/name=oai-nr-ue -n oai-ue -c nr-ue --kubeconfig "$kubeconfig" --tail 50
+            error "Timed out waiting for $msg"
+        fi
+        timeout=$((timeout - 5))
+        sleep 5
+        kubectl logs "$(kubectl get pods -n oai-ue --kubeconfig "$kubeconfig" -l app.kubernetes.io/name=oai-nr-ue -o jsonpath='{.items[*].metadata.name}')" -n oai-ue -c nr-ue --kubeconfig "$kubeconfig" >temp_file
     done
     debug "timeout: $timeout"
     rm "${temp_file}"

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1396,7 +1396,7 @@ periodics:
             - "-c"
             - |
               set -eE; cd "$GOPATH/src/nephio_repo/test-infra/e2e/terraform"; trap 'terraform destroy -target module.gcp-ubuntu-focal -auto-approve' EXIT;
-              terraform init && timeout 75m terraform apply -target module.gcp-ubuntu-focal -auto-approve
+              terraform init && timeout 120m terraform apply -target module.gcp-ubuntu-focal -auto-approve
           volumeMounts:
             - name: satoken
               mountPath: "/etc/satoken"
@@ -1451,7 +1451,7 @@ periodics:
             - "-c"
             - |
               set -eE; cd "$GOPATH/src/nephio_repo/test-infra/e2e/terraform"; trap 'terraform destroy -target module.gcp-fedora-34 -auto-approve' EXIT;
-              terraform init && timeout 75m terraform apply -target module.gcp-fedora-34 -auto-approve
+              terraform init && timeout 120m terraform apply -target module.gcp-fedora-34 -auto-approve
           volumeMounts:
             - name: satoken
               mountPath: "/etc/satoken"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
The current test-infra End-to-End testing behavior continues executing tests until the end. In some cases, this could extend the testing time and block or misuse the CI resources. This change enables a feature to stop the End-to-End execution if a failure is previously raised.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
