### PR TITLE
Fix one-liner bash Sandbox install

### DIFF
--- a/e2e/provision/init.sh
+++ b/e2e/provision/init.sh
@@ -57,7 +57,7 @@ DEPLOYMENT_TYPE=${NEPHIO_DEPLOYMENT_TYPE:-$(get_metadata nephio-setup-type "r1")
 RUN_E2E=${NEPHIO_RUN_E2E:-$(get_metadata nephio-run-e2e "false")}
 REPO=${NEPHIO_REPO:-$(get_metadata nephio-test-infra-repo "https://github.com/nephio-project/test-infra.git")}
 BRANCH=${NEPHIO_BRANCH:-$(get_metadata nephio-test-infra-branch "main")}
-NEPHIO_USER=${NEPHIO_USER:-$(get_metadata nephio-user "ubuntu")}
+NEPHIO_USER=${NEPHIO_USER:-$(get_metadata nephio-user "${USER:-ubuntu}")}
 NEPHIO_CATALOG_REPO_URI=${NEPHIO_CATALOG_REPO_URI:-$(get_metadata nephio-catalog-repo-uri "https://github.com/nephio-project/catalog.git")}
 export ANSIBLE_CMD_EXTRA_VAR_LIST="nephio_catalog_repo_uri='$NEPHIO_CATALOG_REPO_URI'"
 HOME=${NEPHIO_HOME:-/home/$NEPHIO_USER}

--- a/e2e/provision/playbooks/roles/bootstrap/README.md
+++ b/e2e/provision/playbooks/roles/bootstrap/README.md
@@ -14,9 +14,10 @@ Available variables are listed below, along with default values (see defaults/ma
 
 | Variable                        | Required | Default                                                       | Choices                   | Comments                                                                          |
 |---------------------------------|----------|---------------------------------------------------------------|---------------------------|-----------------------------------------------------------------------------------|
-| host_min_vcpu                   | no       | 8                                                             |                           | Minimum vCPUs required                                                            |
-| host_min_cpu_ram                | no       | 16                                                            |                           | Minimum RAM required (GB)                                                         |
-| host_min_root_disk_space        | no       | 50                                                            |                           | Minimum disk space required (GB)                                                  |
+| host_reqs.sanbox.vcpu           | no       | 6                                                             |                           | Minimum vCPUs required for Sandbox installation                                   |
+| host_reqs.sanbox.memory         | no       | 6                                                             |                           | Minimum RAM required (GB ) for Sandbox installation                               |
+| host_reqs.end_to_end.vcpu       | no       | 16                                                            |                           | Minimum vCPUs required for executing End-to-End testing                           |
+| host_reqs.end_to_end.memory     | no       | 32                                                            |                           | Minimum RAM required (GB ) for executing End-to-End testing                       |
 | container_engine                | no       | docker                                                        | docker                    | Container engine utilized for the management cluster creation                     |
 | gtp5g_dest                      | no       | /opt/gtp5g                                                    |                           | Destination path for GTP5G source code                                            |
 | gtp5g_version                   | no       | v0.6.8                                                        |                           | GTP5G source code version                                                         |

--- a/e2e/provision/playbooks/roles/bootstrap/defaults/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/defaults/main.yml
@@ -8,9 +8,13 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 ##############################################################################
 
-host_min_vcpu: 8  # minimum required vCPUs before install
-host_min_cpu_ram: 16  # minimum required CPU RAM before install; value in GB
-host_min_root_disk_space: 50  # minimum required disk space before install; value in GB
+host_reqs:
+  sandbox:
+    vcpu: 6  # minimum vCPUs required for the Sandbox installation
+    memory: 6  # minimum memory required for the Sandbox installation
+  end_to_end:
+    vcpu: 16
+    memory: 32
 
 container_engine: docker
 

--- a/e2e/provision/playbooks/roles/bootstrap/molecule/ci/molecule.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/molecule/ci/molecule.yml
@@ -66,8 +66,10 @@ provisioner:
   inventory:
     group_vars:
       all:
-        host_min_vcpu: 2
-        host_min_cpu_ram: 1
+        host_reqs:
+          sandbox:
+            vcpu: 2
+            memory: 1
 verifier:
   name: testinfra
   directory: ${MOLECULE_PROJECT_DIRECTORY}/molecule/default/tests

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
@@ -13,6 +13,7 @@
 
 - name: Load gtp5g kernel module
   ansible.builtin.include_tasks: load-gtp5g-module.yml
+  when: lookup('ansible.builtin.env', 'E2ETYPE', default='free5gc') == 'free5gc'
 
 - name: Load sctp kernel module
   ansible.builtin.include_tasks: load-sctp-module.yml

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/prechecks.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/prechecks.yml
@@ -8,6 +8,11 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 ##############################################################################
 
+- name: Define Hardware requirements
+  ansible.builtin.set_fact:
+    host_min_vcpu: lookup('ansible.builtin.env', 'RUN_E2E', default=false) | ternary(host_reqs.end_to_end.vcpu, host_reqs.sandbox.vcpu)
+    host_min_cpu_ram: lookup('ansible.builtin.env', 'RUN_E2E', default=false) | ternary(host_reqs.end_to_end.memory, host_reqs.sandbox.memory)
+
 - name: Checking host has minimum number of CPUS
   ansible.builtin.assert:
     that: ansible_facts.processor_vcpus >= host_min_vcpu | int


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
These changes fix the one-liner bash Sandbox install instruction `curl -fsSL https://raw.githubusercontent.com/nephio-project/test-infra/main/e2e/provision/init.sh | sudo -E bash` which in some cases can be useful to provision Nephio Sandboxes. It also separates the Sandbox Hardware requirements from the requirements to execute End-to-End tests and tries to reduce the provisioning time by skipping the building/loading gtp5g kernel module in OAI test cases.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
