### PR TITLE
Enable periodic task execution for OAI End-to-End testing

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1231,7 +1231,7 @@ presubmits:
             - "--prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)"
 
 periodics:
-  - name: e2e-ubuntu-focal-daily
+  - name: e2e-daily-ubuntu-focal-free5gc
     annotations:
     labels:
     cron: "0 15 * * 1-5"
@@ -1286,7 +1286,7 @@ periodics:
             items:
               - key: nephio.yaml
                 path: nephio.yaml
-  - name: e2e-fedora-34-daily
+  - name: e2e-daily-fedora-34-free5gc
     annotations:
     labels:
     cron: "0 15 * * 1-5"
@@ -1308,6 +1308,61 @@ periodics:
             - |
               set -eE; cd "$GOPATH/src/nephio_repo/test-infra/e2e/terraform"; trap 'terraform destroy -target module.gcp-fedora-34 -auto-approve' EXIT;
               terraform init && timeout 120m terraform apply -target module.gcp-fedora-34 -auto-approve
+          volumeMounts:
+            - name: satoken
+              mountPath: "/etc/satoken"
+            - name: ssh-key-vol
+              mountPath: "/etc/ssh-key"
+            - name: nephio-e2e-yaml
+              mountPath: "/etc/nephio"
+          resources:
+            requests:
+              cpu: 2
+              memory: 2Gi
+      volumes:
+        - name: satoken
+          secret:
+            secretName: satoken
+            items:
+              - key: satoken
+                path: satoken
+        - name: ssh-key-vol
+          secret:
+            secretName: ssh-key-e2e
+            defaultMode: 256
+            items:
+              - key: id_rsa
+                path: id_rsa
+              - key: id_rsa.pub
+                path: id_rsa.pub
+        - name: nephio-e2e-yaml
+          secret:
+            secretName: nephio-e2e-yaml
+            items:
+              - key: nephio.yaml
+                path: nephio.yaml
+  - name: e2e-daily-ubuntu-jammy-oai
+    annotations:
+    labels:
+    cron: "0 15 * * 1-5"
+    skip_report: false
+    decorate: true
+    cluster: default
+    extra_refs:
+      - org: nephio-project
+        repo: test-infra
+        base_ref: main
+        path_alias: nephio_repo/test-infra
+    spec:
+      containers:
+        - image: "nephio/e2e:latest"
+          command:
+            - "/bin/sh"
+          args:
+            - "-c"
+            - |
+              set -eE; cd "$GOPATH/src/nephio_repo/test-infra/e2e/terraform"; trap 'terraform destroy -target module.gcp-ubuntu-jammy -auto-approve' EXIT;
+              terraform init && timeout 120m terraform apply -target module.gcp-ubuntu-jammy -var="e2e_type=oai" -auto-approve
           volumeMounts:
             - name: satoken
               mountPath: "/etc/satoken"

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1344,7 +1344,7 @@ periodics:
   - name: e2e-daily-ubuntu-jammy-oai
     annotations:
     labels:
-    cron: "0 15 * * 1-5"
+    cron: "0 15 * * 1-6"
     skip_report: false
     decorate: true
     cluster: default


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
Until now, OAI e2e execution is done on demand basis. That restriction limits the capability for catching errors on new changes. This change enables the End-to-End test execution for OAI use case.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
