### PR TITLE
Adding a label for stock repos to be visible in external blueprints

### DIFF
--- a/e2e/provision/playbooks/roles/install/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/install/tasks/main.yml
@@ -85,6 +85,9 @@
       metadata:
         name: "{{ item.name }}"
         namespace: default
+        labels:
+          kpt.dev/repository-access: read-only
+          kpt.dev/repository-content: external-blueprints
       spec:
         content: Package
         deployment: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**

 /kind feature

**What this PR does / why we need it**:

Stock repos are not visible as `external-blueprints` the tutorial will not properly. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # Deploying `free5gc-cp` via the webui in the r2 docs

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
