### PR TITLE
Add porchctl bin to sandbox install

### DIFF
--- a/e2e/provision/playbooks/cluster.yml
+++ b/e2e/provision/playbooks/cluster.yml
@@ -123,6 +123,14 @@
             state: true
             persistent: true
           when: ansible_os_family == 'RedHat'
+    - name: Unarchive /tmp/porchctl.tgz into /usr/local/bin/
+      become: true
+      become_user: root
+      ansible.builtin.unarchive:
+        remote_src: true
+        src: https://github.com/nephio-project/porch/releases/download/v2.0.0/porchctl_2.0.0_linux_amd64.tar.gz
+        dest: /usr/local/bin/
+        creates: /usr/local/bin/porchctl
   roles:
     - bootstrap
     - install


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
Adds the porchctl binary to the sandbox installation.
The porchctl cmd replaces the kpt alpha cmd set.

**Which issue(s) this PR fixes**:
Adds the missing porchctl binary

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
NA

**Does this PR introduce a user-facing change?**:
Addition of new porchctl commands
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add the porchctl cli tool
```
