### PR TITLE
Adding packer to build Nephio pre-baked image

### DIFF
--- a/.github/workflows/nephio-packer-gcp.yaml
+++ b/.github/workflows/nephio-packer-gcp.yaml
@@ -1,0 +1,51 @@
+name: Nephio Packer GCP Build
+
+on:
+  push:
+    branches: [add_packer_build]
+    paths-ignore: ['**/README.md', 'prow/*', 'tools/*', 'images/*']
+
+env:
+  PRODUCT_VERSION: "1.8.6"
+
+jobs:
+  packer-nephio-pre-backed-image:
+    name: Build Nephio pre-baked image
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./e2e/packer/gcp
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+        
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP
+        id: 'auth'
+        uses: 'google-github-actions/auth@v2'
+        with:
+            workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'
+            service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
+
+      - name: Setup `packer`
+        uses: hashicorp/setup-packer@main
+        id: setup
+        with:
+          version: ${{ env.PRODUCT_VERSION }}
+
+      - name: Run `packer init`
+        id: init
+        run: "packer init ./nephio-packer.pkr.hcl"
+
+      - name: Run `packer validate`
+        id: validate
+        run: "packer validate -syntax-only -evaluate-datasources ./nephio-packer.pkr.hcl"
+
+      - name: Run `packer build`
+        id: build
+        run: "packer build -force -var 'project_id=${{ vars.GCP_PROJECT_ID }}' -var-file=varibles.pkrvars.hcl ./nephio-packer.pkr.hcl"  
+
+      

--- a/e2e/packer/gcp/nephio-packer.pkr.hcl
+++ b/e2e/packer/gcp/nephio-packer.pkr.hcl
@@ -1,0 +1,63 @@
+packer {
+  required_plugins {
+    googlecompute = {
+      source  = "github.com/hashicorp/googlecompute"
+      version = "~> 1"
+    }
+  }
+}
+
+# Requires Variables for GCP
+variable "project_id" {}
+variable "zone" {}
+variable "source_image" {}
+variable "image_version" {}
+variable "machine_type" {}
+variable "disk_size" {} 
+
+locals {
+    datestamp = formatdate("YYYYMMDD", timestamp())
+    image_version = replace(var.image_version, ".", "-")
+}
+
+source "googlecompute" "nephio-packer" {
+  project_id        = var.project_id
+  zone              = var.zone
+  machine_type      = var.machine_type
+  source_image      = var.source_image
+  ssh_username      = "ubuntu"
+  use_os_login      = "false"
+  disk_size         = var.disk_size
+  image_name        = "nephio-pre-baked-${local.image_version}-ubuntu-${local.datestamp}"
+  image_description = "Nephio pre-backed ubuntu 20.04 image"  
+
+}
+
+build {
+  sources = ["sources.googlecompute.nephio-packer"]
+  provisioner "shell" {
+    expect_disconnect = "true"
+    inline = [
+      "echo '=============================================='",
+      "echo 'APT INSTALL PACKAGES & UPDATES'",
+      "echo '=============================================='",
+      "sudo apt update",
+      "echo '* libraries/restart-without-asking boolean true' | sudo debconf-set-selections",
+      "sudo apt upgrade -y"
+    ]
+  }
+
+  provisioner "shell" {
+    inline = [
+      "echo '=============================================='",
+      "echo 'INSTALL NEPHIO CORE'",
+      "echo '=============================================='",
+      "git clone https://github.com/nephio-project/test-infra.git",
+      "cd test-infra/e2e/provision",
+      "ANSIBLE_CMD_EXTRA_VAR_LIST='DEBUG=true' ./install_sandbox.sh",
+      "echo '=============================================='",
+      "echo 'BUILD COMPLETE'",
+      "echo '=============================================='"
+    ]
+  }
+}

--- a/e2e/packer/gcp/varibles.pkrvars.hcl
+++ b/e2e/packer/gcp/varibles.pkrvars.hcl
@@ -1,0 +1,5 @@
+image_version       = "1.0.0"
+zone                = "europe-west1-b"
+source_image        = "ubuntu-2004-focal-v20240209"
+machine_type        = "e2-standard-8"
+disk_size           = 50

--- a/e2e/terraform/main.tf
+++ b/e2e/terraform/main.tf
@@ -30,3 +30,11 @@ variable "fail_fast" {
   default     = "false"
   type        = string
 }
+
+module "github_action_gcp_resource" {
+  source      = ".//modules/gh_action_resource"
+  project_id  = "pure-faculty-367518"
+  wif_pool_id = "gh-action-wif-pool"
+  github_org  = "nephio-project"
+  github_repo = "test-infra"
+}

--- a/e2e/terraform/modules/gh_action_resource/main.tf
+++ b/e2e/terraform/modules/gh_action_resource/main.tf
@@ -1,0 +1,32 @@
+# Create service account for Github Actions
+data "google_project" "main" {
+  project_id = var.project_id
+}
+
+resource "google_service_account" "packer_sa" {
+  account_id = "github-action-packer-sa"
+  display_name = "Service account for GitHub Actions"
+}
+
+resource "google_project_iam_member" "packer_sa_iam_member" {
+  project = var.project_id
+  count = length(var.packer_sa_iam_roles_list)
+  role = var.packer_sa_iam_roles_list[count.index]
+  member = "serviceAccount:${google_service_account.packer_sa.email}"
+}
+
+# Create Workload Iddentity Fedetation on GCP for Github actions authentication
+module "gh_oidc" {
+  source = "terraform-google-modules/github-actions-runners/google//modules/gh-oidc"
+  version = "3.1.1"
+  
+  project_id = var.project_id
+  pool_id = var.wif_pool_id
+  provider_id = "github"
+  sa_mapping = {
+    "packer-sa" = {
+      sa_name   = google_service_account.packer_sa.id
+      attribute = format("attribute.repository/%s/%s", var.github_org, var.github_repo)
+    }
+  }
+}

--- a/e2e/terraform/modules/gh_action_resource/output.tf
+++ b/e2e/terraform/modules/gh_action_resource/output.tf
@@ -1,0 +1,9 @@
+output "wif_provider" {
+  value = module.gh_oidc.provider_name
+  description = "Workload Identity Federation name"
+}
+
+output "wif_service_account" {
+  value = google_service_account.packer_sa.email
+  description = "Service account name"
+}

--- a/e2e/terraform/modules/gh_action_resource/provider.tf
+++ b/e2e/terraform/modules/gh_action_resource/provider.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = "~> 1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 4.0" 
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}

--- a/e2e/terraform/modules/gh_action_resource/variables.tf
+++ b/e2e/terraform/modules/gh_action_resource/variables.tf
@@ -1,0 +1,38 @@
+variable "project_id" {
+  description = "GCP project ID"
+  default     = "pure-faculty-367518"
+  type        = string
+}
+
+variable "region" {
+  description = "Region to deploy GCP resources"
+  type        = string
+  default     = "europe-west1"
+}
+
+variable "wif_pool_id" {
+  description = "Workload Identity Federation pool ID"
+  default     = "nephio_wif_pool_id"
+  type        = string
+}
+
+variable "packer_sa_iam_roles_list" {
+  description = "List of IAM roles to be assigned to Packer WIF service account"
+  type        = list(string)
+  default = [
+    "roles/compute.instanceAdmin.v1",
+    "roles/iam.serviceAccountUser",
+  ]
+}
+
+variable "github_org" {
+  description = "GitHub repo owner name"
+  default     = "nephio-project"
+  type        = string
+}
+
+variable "github_repo" {
+  description = "GitHub repo name"
+  default     = "test-infra"
+  type        = string
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?** 
/kind feature

**What this PR does / why we need it**:
This PR contains Packer files to build the Nephio pre-baked image on GCP. It also contains terraform files to create required resources on GCP to authenticate Github actions to connect GCP.  It contains GitHub action to automate image building. 
 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #NONE

**Special notes for your reviewer**:
To run the GitHub Actions to build Nephio pre-baked images following secret and variable need to setup in test-infra repo: 
Repository secrets:
1. WIF_PROVIDER
2. WIF_SERVICE_ACCOUNT
Repository variables:
1. GCP_PROJECT_ID

NOTE: Value for WIF_PROVIDER and WIF_SERVICE_ACCOUNT is created by Terraform script in PR
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
``` 
NONE

```
