### PR TITLE
Local and Nephio User Validation

### DIFF
--- a/e2e/provision/init.sh
+++ b/e2e/provision/init.sh
@@ -92,21 +92,19 @@ if ! sudo -u "$NEPHIO_USER" sudo -n "true"; then
     exit 1
 fi
 
+if [[ $(id -u) -ne 0 ]]; then
+    echo ""
+    echo "This script must to be executed by the root user."
+    echo ""
+    exit 1
+fi
 
-#if [[ $(id -u) -eq 0 ]]; then
-#    echo ""
-#    echo "This script needs to be executed without using sudo command."
-#    echo ""
-#    exit 1
-#fi
-#
-#if [[ $(runuser -u "$NEPHIO_USER" -- id -u) -eq 0 ]]; then
-#    echo ""
-#    echo "This script needs to be executed without using sudo command."
-#    echo ""
-#    exit 1
-#fi
-
+if [[ $(sudo -u "$NEPHIO_USER" id -u) -eq 0 ]]; then
+    echo ""
+    echo "NEPHIO_USER cannot be root (user '$(sudo -u "$NEPHIO_USER" id -nu)')."
+    echo ""
+    exit 1
+fi
 
 if ! command -v git >/dev/null; then
     source /etc/os-release || source /usr/lib/os-release

--- a/e2e/provision/init.sh
+++ b/e2e/provision/init.sh
@@ -71,6 +71,43 @@ FAIL_FAST=${FAIL_FAST:-$(get_metadata fail_fast "false")}
 echo "$DEBUG, $DEPLOYMENT_TYPE, $RUN_E2E, $REPO, $BRANCH, $NEPHIO_USER, $HOME, $REPO_DIR, $DOCKERHUB_USERNAME, $DOCKERHUB_TOKEN"
 trap get_status ERR
 
+# Validate root permissions for current user and NEPHIO_USER
+if ! sudo -n "true"; then
+    echo ""
+    echo "Passwordless sudo is needed for '$(id -nu)' user."
+    echo "Please fix your /etc/sudoers file. You likely want an"
+    echo "entry like the following one..."
+    echo ""
+    echo "$(id -nu) ALL=(ALL) NOPASSWD: ALL"
+    exit 1
+fi
+
+if ! sudo -u "$NEPHIO_USER" sudo -n "true"; then
+    echo ""
+    echo "Passwordless sudo is needed for '$(sudo -u "$NEPHIO_USER" id -nu)' user."
+    echo "Please fix your /etc/sudoers file. You likely want an"
+    echo "entry like the following one..."
+    echo ""
+    echo "$(sudo -u "$NEPHIO_USER" id -nu) ALL=(ALL) NOPASSWD: ALL"
+    exit 1
+fi
+
+
+#if [[ $(id -u) -eq 0 ]]; then
+#    echo ""
+#    echo "This script needs to be executed without using sudo command."
+#    echo ""
+#    exit 1
+#fi
+#
+#if [[ $(runuser -u "$NEPHIO_USER" -- id -u) -eq 0 ]]; then
+#    echo ""
+#    echo "This script needs to be executed without using sudo command."
+#    echo ""
+#    exit 1
+#fi
+
+
 if ! command -v git >/dev/null; then
     source /etc/os-release || source /usr/lib/os-release
     case ${ID,,} in


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR validates sudo/root permissions for the current user as well as NEPHIO_USER. This ensures the current user and NEPHIO_USER both have passwordless sudo permissions. It also validates that the current user is root (required for `runuser` commands) and that NEPHIO_USER is not root. This was implemented after discussion about needing improvement to user validation. Special notes below note an alternate implementation, if desired.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
NONE
**Special notes for your reviewer**:
There is an alternate implementation that validates the local user is *not* root, and thus changes the `runuser` commands to be `sudo -u` commands. This may cause user facing changes, and thus this simpler version has been opened for PR, but the other can be viewed [here](https://github.com/nephio-project/test-infra/compare/main...dkosteck:test-infra:nephio-user-sudo-validation-no-runuser).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
User-facing changes exist in that there are new validations that output to stdout, as well as the fact that if validations fail the init.sh will exit with status 1. As root/sudo status is now validated for the user and NEPHIO_USER this may also require change.
```
