### PR TITLE
Proxy Docker calls to private registry

### DIFF
--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -70,3 +70,6 @@ if [[ $failed -gt 0 ]]; then
     echo "FAILED $failed tests"
     exit 1
 fi
+if [ "$(docker container inspect -f '{{.State.Running}}' docker_registry_proxy)" = "true" ]; then
+    echo "Docker registry cache hits: $(docker logs docker_registry_proxy | grep '"upstream_cache_status":"HIT"' | wc -l)"
+fi

--- a/e2e/provision/playbooks/roles/bootstrap/defaults/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/defaults/main.yml
@@ -29,6 +29,9 @@ k8s:
 kind:
   enabled: true
 
+registry:
+  enabled: true
+
 nephio_catalog_repo_uri: https://github.com/nephio-project/catalog.git
 nephio_catalog_revision: main
 

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/create-local_registry.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/create-local_registry.yml
@@ -1,0 +1,46 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2024 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+- name: Create a local docker registry
+  become: true
+  community.docker.docker_container:
+    name: docker_registry_proxy
+    image: rpardini/docker-registry-proxy:0.6.4
+    hostname: docker-registry-proxy
+    detach: true
+    restart: true
+    restart_policy: "always"
+    networks:
+      - name: kind
+    ports:
+      - 0.0.0.0:3128:3128
+    volumes:
+      - /tmp/docker_mirror_cache:/docker_mirror_cache
+      - /tmp/docker_mirror_certs:/ca
+    env:
+      ENABLE_MANIFEST_CACHE: "true"
+      REGISTRIES: "k8s.gcr.io gcr.io quay.io"
+
+- name: Waits for local docker registry readiness
+  ansible.builtin.uri:
+    url: http://127.0.0.1:3128
+  until: _result.status == 200
+  retries: 600
+  delay: 1
+  register: _result
+
+- name: Disable IPv6 DNS resolvers
+  become: true
+  community.docker.docker_container_exec:
+    container: docker_registry_proxy
+    argv:
+      - /bin/bash
+      - -c
+      - 'echo "resolver 8.8.8.8 4.2.2.2 ipv6=off;" > /etc/nginx/resolvers.conf && /usr/sbin/nginx -s reload'

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/create-local_registry.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/create-local_registry.yml
@@ -12,7 +12,7 @@
   become: true
   community.docker.docker_container:
     name: docker_registry_proxy
-    image: rpardini/docker-registry-proxy:0.6.4
+    image: rpardini/docker-registry-proxy:0.6.5
     hostname: docker-registry-proxy
     detach: true
     restart: true

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
@@ -25,6 +25,10 @@
   ansible.builtin.include_tasks: create-mgmt.yml
   when: kind.enabled
 
+- name: Create Local Docker Registry
+  ansible.builtin.include_tasks: create-local_registry.yml
+  when: registry.enabled
+
 - name: Apply kpt packages
   ansible.builtin.include_tasks:
     file: apply-pkgs.yml


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This change provides the steps to create a docker registry in the sandbox to keep a cache images and minimize the Docker network consumption. This is accomplished deploying a specialized registry that supports multiple source images and redirecting the requests of workload clusters.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
