### PR TITLE
Remove metallb ip-address pool from edge and regional cluster

### DIFF
--- a/e2e/tests/oai/001b-infra-metal-lb.sh
+++ b/e2e/tests/oai/001b-infra-metal-lb.sh
@@ -66,8 +66,6 @@ function _define_ip_address_pool {
 declare -A clusters
 clusters=(
     ["core"]="172.18.16.0/20"
-    ["regional"]="172.18.32.0/20"
-    ["edge"]="172.18.48.0/20"
 )
 
 # Define MetalLB IP ranges


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
Metallb is not used on regional and edge clusters so we don't need to install ip-address pool resource. This will save some CI time. 
