### PR TITLE
Update gotests to Go 1.22

### DIFF
--- a/images/gotests/Dockerfile
+++ b/images/gotests/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3-bullseye as builder
+FROM golang:1.22.2-bullseye as builder
 ARG ctrl_tools_ver=0.12.0
 WORKDIR /go/src/
 ADD https://github.com/kubernetes-sigs/controller-tools/archive/refs/tags/v$ctrl_tools_ver.tar.gz ./
@@ -11,7 +11,7 @@ RUN git clone https://github.com/kubernetes/test-infra.git
 WORKDIR /go/src/test-infra/robots/coverage
 RUN go build -o /tmp/ ./...
 
-FROM golang:1.21.3-bullseye
+FROM golang:1.22.2-bullseye
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR updates the go tests to use go 1.22

**Which issue(s) this PR fixes**:
Fixes [Issue-510](https://github.com/nephio-project/nephio/issues/510).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
