### PR TITLE
Enable Fedora 38 support to OAI test case

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -246,7 +246,7 @@ presubmits:
                 path: id_rsa
               - key: id_rsa.pub
                 path: id_rsa.pub
-  - name: e2e-oai-fedora-34
+  - name: e2e-oai-fedora-38
     annotations:
     labels:
     run_if_changed: '^e2e/'
@@ -262,8 +262,8 @@ presubmits:
           args:
             - "-c"
             - |
-              set -eE; cd "$(git rev-parse --show-toplevel)/e2e/terraform"; trap 'terraform destroy -target module.gcp-fedora-34 -auto-approve' EXIT;
-              terraform init && timeout 120m terraform apply -target module.gcp-fedora-34 -var="e2e_type=oai" -var="fail_fast=true" -auto-approve
+              set -eE; cd "$(git rev-parse --show-toplevel)/e2e/terraform"; trap 'terraform destroy -target module.gcp-fedora-38 -auto-approve' EXIT;
+              terraform init && timeout 120m terraform apply -target module.gcp-fedora-38 -var="e2e_type=oai" -var="fail_fast=true" -auto-approve
           volumeMounts:
             - name: satoken
               mountPath: "/etc/satoken"

--- a/e2e/provision/distros_supported.yml
+++ b/e2e/provision/distros_supported.yml
@@ -21,3 +21,7 @@ fedora_34:
   reload: true
   project_id: fedora-cloud
   family: fedora-cloud-34
+fedora_38:
+  name: fedora/38-cloud-base
+  project_id: fedora-cloud
+  family: fedora-cloud-38

--- a/e2e/provision/playbooks/roles/bootstrap/molecule/default/molecule.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/molecule/default/molecule.yml
@@ -45,6 +45,14 @@ platforms:
       gui: false
     groups:
       - fedora
+  - name: fedora38-$POSFIX_NAME
+    box: generic/fedora38
+    memory: 8192
+    cpus: 4
+    provider_options:
+      gui: false
+    groups:
+      - fedora
 provisioner:
   name: ansible
   env:

--- a/e2e/terraform/main.tf
+++ b/e2e/terraform/main.tf
@@ -19,6 +19,14 @@ module "gcp-fedora-34" {
   nephio_e2e_fail_fast = var.fail_fast
 }
 
+module "gcp-fedora-38" {
+  source               = ".//modules/gcp"
+  vmimage              = "fedora-cloud/fedora-cloud-38"
+  ansible_user         = "fedora"
+  nephio_e2e_type      = var.e2e_type
+  nephio_e2e_fail_fast = var.fail_fast
+}
+
 variable "e2e_type" {
   description = "The End-to-End testing type"
   default     = "free5gc"

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1594,7 +1594,7 @@ periodics:
                 path: id_rsa
               - key: id_rsa.pub
                 path: id_rsa.pub
-  - name: e2e-daily-oai-fedora-34
+  - name: e2e-daily-oai-fedora-38
     annotations:
     labels:
     cron: "0 15 * * 1-6"
@@ -1614,8 +1614,8 @@ periodics:
           args:
             - "-c"
             - |
-              set -eE; cd "$GOPATH/src/nephio_repo/test-infra/e2e/terraform"; trap 'terraform destroy -target module.gcp-fedora-34 -auto-approve' EXIT;
-              terraform init && timeout 120m terraform apply -target module.gcp-fedora-34 -var="e2e_type=oai" -auto-approve
+              set -eE; cd "$GOPATH/src/nephio_repo/test-infra/e2e/terraform"; trap 'terraform destroy -target module.gcp-fedora-38 -auto-approve' EXIT;
+              terraform init && timeout 120m terraform apply -target module.gcp-fedora-38 -var="e2e_type=oai" -auto-approve
           volumeMounts:
             - name: satoken
               mountPath: "/etc/satoken"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
Until now, the creation of the sandbox has been tested with three OS releases, used for testing four different scenarios. This change offers the option to validate the Sandbox creation with fedora38, covering OAI test case.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
