### PR TITLE
Upgrade gtp5g version and enable verifiers

### DIFF
--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -23,11 +23,13 @@ source "$LIBDIR/testing.sh"
 
 failed=$((0))
 test_summary=""
+sudo dmesg >/tmp/e2e_dmesg_base.log
 for t in $TESTDIR/*.sh; do
     if ! run_test "$t"; then
         failed=$((failed + 1))
         [[ ${FAIL_FAST:-false} != "true" ]] || break
     fi
+    sudo dmesg >/tmp/e2e_dmesg_base.log
 done
 echo "TEST SUMMARY"
 echo "------------"

--- a/e2e/provision/init.sh
+++ b/e2e/provision/init.sh
@@ -32,6 +32,11 @@ function get_status {
         docker stats --no-stream
         docker ps --size
     fi
+    if [ -f /tmp/e2e_dmesg_base.log ]; then
+        echo "Kernel diagnostic messages:"
+        sudo dmesg >/tmp/e2e_dmesg_current.log
+        diff /tmp/e2e_dmesg_base.log /tmp/e2e_dmesg_current.log
+    fi
     if command -v kubectl >/dev/null; then
         echo "Draft Porch Package Revisions"
         kubectl get packagerevision -o jsonpath='{range .items[?(@.spec.lifecycle=="Draft")]}{.metadata.name}{"\n"}{end}' || :

--- a/e2e/provision/playbooks/roles/bootstrap/defaults/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/defaults/main.yml
@@ -19,7 +19,7 @@ host_reqs:
 container_engine: docker
 
 gtp5g_dest: /opt/gtp5g
-gtp5g_version: v0.8.3
+gtp5g_version: v0.8.8
 gtp5g_tarball_url: "https://github.com/free5gc/gtp5g/archive/refs/tags/{{ gtp5g_version }}.tar.gz"
 
 k8s:

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/load-gtp5g-module.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/load-gtp5g-module.yml
@@ -17,6 +17,11 @@
         - "{{ ansible_os_family | lower }}.yml"
       skip: true
 
+- name: Ensure gtp5g kernel constraints
+  ansible.builtin.assert:
+    that: 'ansible_facts.kernel == "5.0.0-23-generic" or {{ ansible_facts.kernel | replace("-generic", "") is version("5.4", ">=") }}'
+    fail_msg: "{{ ansible_facts.kernel }} version not supported by gtp5g module"
+
 - name: Install compilation packages and kernel development tools on {{ ansible_os_family }}
   become: true
   ansible.builtin.package:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
In some scenarios the [free5gc validation](https://github.com/nephio-project/test-infra/blob/main/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml#L16) could not be suficient to prevent the execution of the gtp5g playbook, this requires an additional check to ensure that VM is using the correct kernel version. This change provides an assertion in to the code and upgrades the code version utilized.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
