### PR TITLE
adds support in scripts for deploying nephio components on real K8S(non-kind)

### DIFF
--- a/e2e/provision/init.sh
+++ b/e2e/provision/init.sh
@@ -72,14 +72,22 @@ REPO=${NEPHIO_REPO:-$(get_metadata nephio-test-infra-repo "https://github.com/ne
 BRANCH=${NEPHIO_BRANCH:-$(get_metadata nephio-test-infra-branch "main")}
 NEPHIO_USER=${NEPHIO_USER:-$(get_metadata nephio-user "${USER:-ubuntu}")}
 NEPHIO_CATALOG_REPO_URI=${NEPHIO_CATALOG_REPO_URI:-$(get_metadata nephio-catalog-repo-uri "https://github.com/nephio-project/catalog.git")}
-export ANSIBLE_CMD_EXTRA_VAR_LIST="nephio_catalog_repo_uri='$NEPHIO_CATALOG_REPO_URI'"
+K8S_CONTEXT=${K8S_CONTEXT:-"kind-kind"}
+K8S_VERSION=${K8S_VERSION:-"v1.29.2"}
+export ANSIBLE_CMD_EXTRA_VAR_LIST='{ "nephio_catalog_repo_uri": "'${NEPHIO_CATALOG_REPO_URI}'", "k8s": { "context" : "'${K8S_CONTEXT}'", "version" : "'$K8S_VERSION'" } }'
 HOME=${NEPHIO_HOME:-/home/$NEPHIO_USER}
 REPO_DIR=${NEPHIO_REPO_DIR:-$HOME/test-infra}
 DOCKERHUB_USERNAME=${DOCKERHUB_USERNAME:-""}
 DOCKERHUB_TOKEN=${DOCKERHUB_TOKEN:-""}
 FAIL_FAST=${FAIL_FAST:-$(get_metadata fail_fast "false")}
 
-echo "$DEBUG, $RUN_E2E, $REPO, $BRANCH, $NEPHIO_USER, $HOME, $REPO_DIR, $DOCKERHUB_USERNAME, $DOCKERHUB_TOKEN"
+if [ ${K8S_CONTEXT} == "kind-kind" ]; then
+    export ANSIBLE_TAG=all
+else
+    export ANSIBLE_TAG=nonkind_k8s
+fi
+
+echo "$DEBUG, $RUN_E2E, $REPO, $BRANCH, $NEPHIO_USER, $HOME, $REPO_DIR, $DOCKERHUB_USERNAME, $DOCKERHUB_TOKEN, $ANSIBLE_TAG, $ANSIBLE_CMD_EXTRA_VAR_LIST"
 trap get_status ERR
 
 # Validate root permissions for current user and NEPHIO_USER

--- a/e2e/provision/install_sandbox.sh
+++ b/e2e/provision/install_sandbox.sh
@@ -75,7 +75,7 @@ fact_caching_connection = /tmp
 EOT
 
 # Management cluster creation
-ansible_cmd="$(command -v ansible-playbook) -i 127.0.0.1, playbooks/cluster.yml "
+ansible_cmd="$(command -v ansible-playbook) -i 127.0.0.1, playbooks/cluster.yml --tags ${ANSIBLE_TAG} "
 [[ ${DEBUG:-false} != "true" ]] || ansible_cmd+="-vvv "
 if [ -n "${ANSIBLE_CMD_EXTRA_VAR_LIST:-}" ]; then
     ansible_cmd+=" --extra-vars=\"${ANSIBLE_CMD_EXTRA_VAR_LIST}\""

--- a/e2e/provision/playbooks/cluster.yml
+++ b/e2e/provision/playbooks/cluster.yml
@@ -41,6 +41,8 @@
       become: true
       ansible.builtin.pip:
         name: kubernetes==26.1.0
+      tags:
+        - nonkind_k8s
     - name: Install Docker Engine
       become: true
       when: (container_engine is not defined) or (container_engine == "docker")
@@ -89,6 +91,11 @@
     - name: Install kpt command-line
       ansible.builtin.include_role:
         name: andrewrothstein.kpt
+        apply:
+          tags:
+            - nonkind_k8s
+      tags:
+        - always
       vars:
         kpt_ver: '1.0.0-beta.49'
         kpt_checksums:
@@ -135,11 +142,18 @@
         creates: /usr/local/bin/porchctl
   roles:
     - bootstrap
-    - install
+    - role: install
+      tags:
+        - always
   tasks:
     - name: Deploy repositories
       ansible.builtin.include_role:
         name: kpt
+        apply:
+          tags:
+            - nonkind_k8s
+      tags:
+        - always
       loop:
         - {pkg: distros/sandbox/repository, dest: /tmp/repository/mgmt}
         - {pkg: nephio/optional/rootsync, dest: /tmp/rootsync/mgmt}
@@ -162,6 +176,8 @@
       until: job_result.finished
       retries: 90
       delay: 10
+      tags:
+        - nonkind_k8s
     - name: Wait for repositories
       kubernetes.core.k8s:
         context: "{{ k8s.context }}"
@@ -178,3 +194,5 @@
       loop:
         - mgmt
         - mgmt-staging
+      tags:
+        - nonkind_k8s

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
@@ -26,9 +26,17 @@
   when: kind.enabled
 
 - name: Apply kpt packages
-  ansible.builtin.include_tasks: apply-pkgs.yml
+  ansible.builtin.include_tasks:
+    file: apply-pkgs.yml
+    apply:
+      tags:
+        - nonkind_k8s
+  tags:
+    - always
 
 - name: Create docker hub secret
+  tags:
+    - nonkind_k8s
   when:
     - lookup('ansible.builtin.env', 'DOCKERHUB_USERNAME') | length > 0
     - lookup('ansible.builtin.env', 'DOCKERHUB_TOKEN') | length > 0


### PR DESCRIPTION


<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

kind feature

> /kind flake

**What this PR does / why we need it**:
This PR allows for deploying nephio management components on pre-existing K8S cluster using the existing scripts. On a machine with K8S installed, one would be able to execute the below command with correct values to install Nephio management components.

`wget -O - https://raw.githubusercontent.com/nephio-project/test-infra/v2.0.0/e2e/provision/init.sh |  sudo NEPHIO_DEBUG=false NEPHIO_BRANCH=v2.0.0 NEPHIO_USER=ubuntu K8S_CONTEXT=kubernetes-admin@kubernetes bash
`

The value for K8S_CONTEXT can be obtained by executing the below command
`kubectl config get-contexts
`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
