### PR TITLE
Fix Ansible linting issues

### DIFF
--- a/e2e/provision/init.sh
+++ b/e2e/provision/init.sh
@@ -27,6 +27,8 @@ function get_status {
         printf "Memory free(Kb):"
         awk -v low="$(grep low /proc/zoneinfo | awk '{k+=$2}END{print k}')" '{a[$1]=$2}  END{ print a["MemFree:"]+a["Active(file):"]+a["Inactive(file):"]+a["SReclaimable:"]-(12*low);}' /proc/meminfo
     fi
+    printf "Disk usage: "
+    sudo df -h
     if command -v docker >/dev/null; then
         echo "Docker statistics:"
         docker stats --no-stream

--- a/e2e/provision/playbooks/cluster.yml
+++ b/e2e/provision/playbooks/cluster.yml
@@ -109,11 +109,13 @@
       block:
         - name: Install container lab on Ubuntu family OS
           ansible.builtin.apt:
-            deb: "{{ clab.download_url }}/v{{ clab.version }}/containerlab_{{ clab.version }}_linux_{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}.deb"
+            deb: "{{ clab.download_url }}/v{{ clab.version }}/containerlab_{{ clab.version }}_linux_{{ 'amd64'
+              if ansible_architecture == 'x86_64' else ansible_architecture }}.deb"
           when: ansible_os_family == 'Debian'
         - name: Install container lab on RedHat family OS
-          ansible.builtin.yum:
-            name: "{{ clab.download_url }}/v{{ clab.version }}/containerlab_{{ clab.version }}_linux_{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}.rpm"
+          ansible.builtin.dnf:
+            name: "{{ clab.download_url }}/v{{ clab.version }}/containerlab_{{ clab.version }}_linux_{{ 'amd64'
+              if ansible_architecture == 'x86_64' else ansible_architecture }}.rpm"
             state: present
             disable_gpg_check: true
           when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
`ansible.builtin.yum` seems to be finally deprecated in favor of `ansible.builtin.dnf` module, this decision is impacting the Ansible linting process. It was also reduced the length of the variables and included a disk usage metric.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
