### PR TITLE
Revert "Update Dockerfile - version bump."

### DIFF
--- a/images/molecule/Dockerfile
+++ b/images/molecule/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.12-slim
+FROM python:3.11-slim
 
 ENV USER root
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  openssh-client=1:9.2p1-2+deb12u2 \
+  openssh-client=1:9.2p1-2+deb12u1 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
-  && pip install --no-cache-dir tox==4.15.1
+  && pip install --no-cache-dir tox==4.11.3


### PR DESCRIPTION
Reverts nephio-project/test-infra#270
Seems like it might cause molecule errors in bootstrap-integration tests, reverting for now, it will have to be worked on after the release