### PR TITLE
Bumping openssh-client version to unbroke build after the revert of 276

### DIFF
--- a/images/molecule/Dockerfile
+++ b/images/molecule/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 ENV USER root
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  openssh-client=1:9.2p1-2+deb12u1 \
+  openssh-client=1:9.2p1-2+deb12u2 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && pip install --no-cache-dir tox==4.11.3


### PR DESCRIPTION
Seems like tox version bump  might cause molecule errors in bootstrap-integration tests, reverting for now, it will have to be worked on after the release, this will fix failing image build by bumpping openssh-client version to one present in repositories.