### PR TITLE
fix: Add latest tag for releaser image

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -311,6 +311,7 @@ postsubmits:
             - |
               executor --context=${PWD}/images/releaser \
                 --dockerfile=Dockerfile --destination=nephio/releaser:${PULL_BASE_REF} \
+                --destination=nephio/releaser:latest
           volumeMounts:
             - name: kaniko-secret
               mountPath: /kaniko/.docker/


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
 /kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR addresses an issue with automated image signing introduced in #266. In #266 we missed tagging the `nephio/releaser` image with `latest` tag. This caused the image signing process to fail because all images tried to pull `nephio/releaser:latest` but couldn't find it.

This PR fixes the issue by ensuring the `nephio/releaser` image is tagged with the `latest` tag along with `${PULL_BASE_REF}`. This will allow all images to successfully pull and use the `nephio/releaser:latest` image for signing.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #266 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No.
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
