### PR TITLE
Revert "Autodestroy CI VMs after two hours"

### DIFF
--- a/e2e/terraform/modules/gcp/main.tf
+++ b/e2e/terraform/modules/gcp/main.tf
@@ -1,18 +1,11 @@
 terraform {
   required_providers {
     random = "~> 3.5"
-    google = "~> 5.27"
+    google = "~> 4.80"
   }
 }
 
 provider "google" {
-  credentials = file(var.credentials)
-  project     = var.project
-  region      = var.region
-  zone        = var.zone
-}
-
-provider "google-beta" {
   credentials = file(var.credentials)
   project     = var.project
   region      = var.region
@@ -28,7 +21,7 @@ resource "random_string" "vm-name" {
 }
 
 locals {
-  vm-name = "e2e-vm-${random_string.vm-name.result}"
+  vm-name    = "e2e-vm-${random_string.vm-name.result}"
 }
 
 resource "google_compute_instance" "lab_instances" {
@@ -55,7 +48,6 @@ resource "google_compute_instance" "lab_instances" {
 }
 
 resource "google_compute_instance" "e2e_instances" {
-  provider                  = google-beta
   count                     = var.nephio_e2e_nodes
   name                      = local.vm-name
   machine_type              = var.instance
@@ -110,15 +102,5 @@ resource "google_compute_instance" "e2e_instances" {
       "chmod +x init.sh",
       "sudo -E FAIL_FAST=${var.nephio_e2e_fail_fast} E2ETYPE=${var.nephio_e2e_type} NEPHIO_REPO_DIR=/home/${var.ansible_user}/test-infra NEPHIO_DEBUG=true NEPHIO_RUN_E2E=true NEPHIO_USER=${var.ansible_user} ./init.sh"
     ]
-  }
-  scheduling {
-    max_run_duration {
-      seconds = 2 * 60 * 60
-    }
-    instance_termination_action = "DELETE"
-    on_host_maintenance         = "TERMINATE"
-    preemptible                 = true
-    automatic_restart           = false
-    provisioning_model          = "SPOT"
   }
 }


### PR DESCRIPTION
Reverts nephio-project/test-infra#263

Seems like preemptive VM provisioning might have negative impact on e2e tests stability and performance

https://cloud.google.com/compute/docs/instances/create-use-preemptible

> Preemptible VMs are available at up to a 60-91% discount compared to the price of standard VMs. However, Compute Engine might stop (preempt) these VMs if it needs to reclaim those resources for other tasks. Preemptible VMs always stop after 24 hours. Preemptible VMs are recommended only for fault-tolerant applications that can withstand VM preemption. Make sure your application can handle preemptions before you decide to create a preemptible VM. To understand the risks and value of preemptible VMs, read the [preemptible VM instances](https://cloud.google.com/compute/docs/instances/preemptible) documentation.

> Caution: Preemptible VMs are not covered by any Service Level Agreement and are excluded from the [Compute Engine SLA](https://cloud.google.com/compute/sla). For more information, see [limitations of preemptible VM instances](https://cloud.google.com/compute/docs/instances/preemptible#limitations)