### PR TITLE
Removing invalidcommitmsg plugin

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -7,7 +7,6 @@ plugins:
     - help
     - heart
     - hold
-    - invalidcommitmsg
     - label
     - lgtm
     - trigger
@@ -28,7 +27,6 @@ plugins:
     - help
     - heart
     - hold
-    - invalidcommitmsg
     - label
     - lgtm
     - trigger


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
invalidcommitmsg plugin checks for 'hash' or 'at' in commit msg which might trigger some actions in GitHub like closing issues. We don't have this problem and it prevents from linking to issue or adding 'fixes...'
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
