### PR TITLE
Set explicit inventory parameters while installing porch

### DIFF
--- a/e2e/provision/playbooks/roles/install/defaults/main.yml
+++ b/e2e/provision/playbooks/roles/install/defaults/main.yml
@@ -69,6 +69,9 @@ nephio:
         version: main
         async: 480
         poll: 5
+        inventory_id: nephio
+        resourcegroup_name: porch
+        resourcegroup_ns: porch-system
       - repo_uri: "{{ nephio_catalog_repo_uri }}"
         pkg: nephio/core/nephio-operator
         version: main

--- a/e2e/provision/playbooks/roles/install/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/install/tasks/main.yml
@@ -23,6 +23,9 @@
     context: "{{ k8s.context }}"
     kpt_async: "{{ item.async }}"
     kpt_poll: "{{ item.poll }}"
+    inventory_id: "{{ item.inventory_id | default(omit) }}"
+    resourcegroup_name: "{{ item.resourcegroup_name | default(omit) }}"
+    resourcegroup_ns: "{{ item.resourcegroup_ns | default(omit) }}"
 
 - name: Wait for packages to be applied
   ansible.builtin.async_status:

--- a/e2e/provision/playbooks/roles/kpt/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/kpt/tasks/main.yml
@@ -74,6 +74,9 @@
     version: "{{ version }}"
     context: "{{ context }}"
     command: live-init
+    inventory_id: "{{ inventory_id | default(omit) }}"
+    name: "{{ resourcegroup_name | default(omit) }}"
+    namespace: "{{ resourcegroup_ns | default(omit) }}"
   register: kpt_live_init
   when: not kpt_resourcegroup.stat.exists
 


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

Sets the inventory-id, resource group name and namespace parameters of the `kpt live init` call for the porch kpt package.

Setting these parameters explicitly (as opposed to using the default random values) will help us to use the sandbox for porch development, and it shouldn't make any noticeable difference for normal users of the Nephio sandbox VM.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

no issue

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

no


