### PR TITLE
Delete a Dockerhub secret before attempting to create on during init

### DIFF
--- a/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
@@ -34,6 +34,18 @@
   tags:
     - always
 
+- name: Delete docker hub secret
+  tags:
+    - nonkind_k8s
+  when:
+    - lookup('ansible.builtin.env', 'DOCKERHUB_USERNAME') | length > 0
+    - lookup('ansible.builtin.env', 'DOCKERHUB_TOKEN') | length > 0
+  block:
+    - name: Delete docker-registry secret
+      ansible.builtin.command: >
+        kubectl delete secret dockerhub -n {{ gitea.k8s.namespace }} --ignore-not-found=true
+      changed_when: false
+
 - name: Create docker hub secret
   tags:
     - nonkind_k8s

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
@@ -45,7 +45,7 @@
     token: "{{ lookup('ansible.builtin.env', 'DOCKERHUB_TOKEN') }}"
   block:
     - name: Delete docker-registry secret
-      k8s:
+      kubernetes.core.k8s:
         kind: Secret
         namespace: "{{ gitea.k8s.namespace }}"
         name: dockerhub

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
@@ -34,18 +34,6 @@
   tags:
     - always
 
-- name: Delete docker hub secret
-  tags:
-    - nonkind_k8s
-  when:
-    - lookup('ansible.builtin.env', 'DOCKERHUB_USERNAME') | length > 0
-    - lookup('ansible.builtin.env', 'DOCKERHUB_TOKEN') | length > 0
-  block:
-    - name: Delete docker-registry secret
-      ansible.builtin.command: >
-        kubectl delete secret dockerhub -n {{ gitea.k8s.namespace }} --ignore-not-found=true
-      changed_when: false
-
 - name: Create docker hub secret
   tags:
     - nonkind_k8s
@@ -56,6 +44,10 @@
     username: "{{ lookup('ansible.builtin.env', 'DOCKERHUB_USERNAME') }}"
     token: "{{ lookup('ansible.builtin.env', 'DOCKERHUB_TOKEN') }}"
   block:
+    - name: Delete docker-registry secret
+      ansible.builtin.command: >
+        kubectl delete secret dockerhub -n {{ gitea.k8s.namespace }} --ignore-not-found=true
+      changed_when: false
     - name: Create docker-registry secret
       ansible.builtin.command: >
         kubectl create secret docker-registry dockerhub --docker-username={{ username }}

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
@@ -45,9 +45,11 @@
     token: "{{ lookup('ansible.builtin.env', 'DOCKERHUB_TOKEN') }}"
   block:
     - name: Delete docker-registry secret
-      ansible.builtin.command: >
-        kubectl delete secret dockerhub -n {{ gitea.k8s.namespace }} --ignore-not-found=true
-      changed_when: false
+      k8s:
+        kind: Secret
+        namespace: "{{ gitea.k8s.namespace }}"
+        name: dockerhub
+        state: absent
     - name: Create docker-registry secret
       ansible.builtin.command: >
         kubectl create secret docker-registry dockerhub --docker-username={{ username }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
Deletes a dockerhub secret when it is present. This was noted on our testing on Fedora, where when a cluster was in a state that the init needed to be run again, the dockerhub secret needed to be deleted to proceed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
