### PR TITLE
Show the output of `porchctl version` during bootstrap

### DIFF
--- a/e2e/provision/playbooks/cluster.yml
+++ b/e2e/provision/playbooks/cluster.yml
@@ -141,6 +141,12 @@
         src: https://github.com/nephio-project/porch/releases/download/main/porchctl.tgz
         dest: /usr/local/bin/
         creates: /usr/local/bin/porchctl
+    - name: Call porchctl version
+      ansible.builtin.shell: porchctl version
+      register: porchctl_version
+    - name: Show porchctl version
+      ansible.builtin.debug:
+        var: porchctl_version
   roles:
     - bootstrap
     - role: install

--- a/e2e/provision/playbooks/cluster.yml
+++ b/e2e/provision/playbooks/cluster.yml
@@ -142,8 +142,9 @@
         dest: /usr/local/bin/
         creates: /usr/local/bin/porchctl
     - name: Call porchctl version
-      ansible.builtin.shell: porchctl version
+      ansible.builtin.command: porchctl version
       register: porchctl_version
+      changed_when: false
     - name: Show porchctl version
       ansible.builtin.debug:
         var: porchctl_version


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:

It shows the output of the `porchctl version` command as part of the bootstrap ansible playbook.
It helps troubleshooting end-to-end tests by adding the version of `porchctl` to the logs.

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
