### PR TITLE
Adding ansible galaxy install pre_task to deploy_kubeadm_k8s

### DIFF
--- a/e2e/provision/playbooks/deploy_kubeadm_k8s.yml
+++ b/e2e/provision/playbooks/deploy_kubeadm_k8s.yml
@@ -2,6 +2,10 @@
 - name: Deploy k8s using kubeadm on host
   hosts: all
   pre_tasks:
+    - name: Install Prerequisite Collections and Roles
+      community.general.ansible_galaxy_install:
+        type: both
+        requirements_file: ../galaxy-requirements.yml
     - name: Sysctl settings updates
       become: true
       ansible.posix.sysctl:

--- a/e2e/provision/playbooks/deploy_kubeadm_k8s.yml
+++ b/e2e/provision/playbooks/deploy_kubeadm_k8s.yml
@@ -5,7 +5,7 @@
     - name: Install Prerequisite Collections and Roles
       community.general.ansible_galaxy_install:
         type: both
-        requirements_file: ../galaxy-requirements.yml
+        requirements_file: "{{ playbook_dir }}/../galaxy-requirements.yml"
     - name: Sysctl settings updates
       become: true
       ansible.posix.sysctl:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Previously there was a potential condition where the galaxy requirements were not satisfied before running the deploy_kubeadm_k8s.yml script. The install would only happen during init.sh.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
