### PR TITLE
Add fluxcd install by default

### DIFF
--- a/e2e/provision/playbooks/roles/install/defaults/main.yml
+++ b/e2e/provision/playbooks/roles/install/defaults/main.yml
@@ -62,6 +62,7 @@ nephio:
       - config-management-monitoring
       - config-management-system
       - resource-group-system
+      - flux-system
   kpt:
     packages:
       - repo_uri: "{{ nephio_catalog_repo_uri }}"
@@ -87,6 +88,11 @@ nephio:
         version: main
         async: 480
         poll: 0
+      - repo_uri: "{{ nephio_catalog_repo_uri }}"
+        pkg: nephio/optional/fluxcd
+        version: main
+        async: 240
+        poll: 5
 
 nephio_webui:
   k8s:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature

> /kind flake

**What this PR does / why we need it**:
Install the fluxcd gitops agents to the sandbox by default to offer an alternative to configsync.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Install fluxcd controllers (Helm, Kustomize, Source, Notification) to sandbox deployment by default.
```
