### PR TITLE
Bump go version and tools for gotests base image

### DIFF
--- a/images/gotests/Dockerfile
+++ b/images/gotests/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.22.2-bullseye AS builder
-ARG ctrl_tools_ver=0.15.0
+FROM golang:1.23.5-bullseye AS builder
+ARG ctrl_tools_ver=0.17.1
 WORKDIR /go/src/
 ADD https://github.com/kubernetes-sigs/controller-tools/archive/refs/tags/v$ctrl_tools_ver.tar.gz ./
 RUN tar -xzf v$ctrl_tools_ver.tar.gz
@@ -17,17 +17,17 @@ WORKDIR /go/src/lichen
 RUN go build -o /tmp/lichen
 
 
-FROM golang:1.22.2-bullseye
+FROM golang:1.23.5-bullseye
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \
   make=4.3-4.1 && \
   rm -rf /var/lib/apt/lists/* && \
-  wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.57.2 && \
-  wget -O - -q https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s v2.19.0 && \
+  wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.63.4 && \
+  wget -O - -q https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s v2.22.0 && \
   go install github.com/google/addlicense@v1.1.1 && \
   go install github.com/matm/gocov-html/cmd/gocov-html@v1.4.0 && \
-  go install github.com/axw/gocov/gocov@v1.1.0
+  go install github.com/axw/gocov/gocov@latest
 
 COPY --from=builder /tmp/controller-gen /go/bin
 COPY --from=builder /tmp/helpgen /go/bin


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Bump go version in testing base image
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bump gotests base image go version to v1.23.5
```
