### PR TITLE
add missing license headers

### DIFF
--- a/images/e2e/Dockerfile
+++ b/images/e2e/Dockerfile
@@ -1,3 +1,17 @@
+#  Copyright 2025 The Nephio Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 FROM hashicorp/terraform:1.5.7
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]

--- a/images/generic-autobumper/Dockerfile
+++ b/images/generic-autobumper/Dockerfile
@@ -1,3 +1,17 @@
+#  Copyright 2025 The Nephio Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 FROM golang:1.22 AS builder
 RUN git clone --depth 1 https://github.com/kubernetes-sigs/prow.git /opt/prow
 

--- a/images/gotests/Dockerfile
+++ b/images/gotests/Dockerfile
@@ -1,3 +1,17 @@
+#  Copyright 2025 The Nephio Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 FROM golang:1.23.5-bullseye AS builder
 ARG ctrl_tools_ver=0.17.1
 WORKDIR /go/src/

--- a/images/gotests/checklicense.sh
+++ b/images/gotests/checklicense.sh
@@ -1,3 +1,17 @@
+#  Copyright 2025 The Nephio Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 #!/bin/sh
 echo "-------------------------------------"
 echo "Those files don't have license header"

--- a/images/label_sync/Dockerfile
+++ b/images/label_sync/Dockerfile
@@ -1,3 +1,17 @@
+#  Copyright 2025 The Nephio Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 FROM golang:1.20.4-alpine3.17 AS builder
 
 WORKDIR /opt

--- a/images/linter/Dockerfile
+++ b/images/linter/Dockerfile
@@ -1,3 +1,17 @@
+#  Copyright 2025 The Nephio Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 FROM python:3.11-slim
 
 RUN pip install --no-cache-dir tox==4.11.3

--- a/images/molecule/Dockerfile
+++ b/images/molecule/Dockerfile
@@ -1,3 +1,17 @@
+#  Copyright 2025 The Nephio Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 FROM python:3.11-slim
 
 ENV USER root

--- a/images/releaser/Dockerfile
+++ b/images/releaser/Dockerfile
@@ -1,3 +1,17 @@
+#  Copyright 2025 The Nephio Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 FROM golang:1.22-alpine AS builder
 
 RUN go install github.com/google/go-containerregistry/cmd/crane@v0.15.2 && \

--- a/tools/release/tag-catalog-packages.sh
+++ b/tools/release/tag-catalog-packages.sh
@@ -1,3 +1,17 @@
+#  Copyright 2025 The Nephio Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 #!/bin/bash
 set -e
 


### PR DESCRIPTION
**What type of PR is this?**
add missing license headers to source code files like` *.go, *.sh and Dockerfile and Makefile`

**What this PR does / why we need it**:
add missing license headers to source code files like` *.go, *.sh and Dockerfile and Makefile`
**Which issue(s) this PR fixes**:
Several source code files has missing license headers as per `FOSSology report`. This PR adds missing license header to those files.

**Special notes for your reviewer**:
This is from `SIG Security` team to comply with `FOSSology report`
**Does this PR introduce a user-facing change?**:
No
