### PR TITLE
adds support for installing CAPI metal3 components

### DIFF
--- a/e2e/provision/playbooks/roles/bootstrap/defaults/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/defaults/main.yml
@@ -102,6 +102,19 @@ cluster_api:
         async: 1500
         poll: 0
 
+cluster_api_nonkind_k8s:
+  enabled: true
+  k8s:
+    namespaces:
+      - capm3-system
+  kpt:
+    packages:
+      - repo_uri: "{{ nephio_catalog_repo_uri }}"
+        pkg: infra/capi/cluster-capi-infrastructure-metal3
+        version: "{{ nephio_catalog_revision }}"
+        async: 1500
+        poll: 0
+
 metallb:
   enabled: true
   k8s:

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/apply-pkgs-nonkind-k8s.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/apply-pkgs-nonkind-k8s.yml
@@ -1,0 +1,51 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2025 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+- name: Init job ids array for nonkind_k8s clusters
+  ansible.builtin.set_fact:
+    all_kpt_apply: []
+
+- name: Create list of packages for install applicable only on nonkind_k8s clusters
+  ansible.builtin.set_fact:
+    cluster_api_nonkind_k8s_pkgs: "{{ cluster_api_nonkind_k8s.enabled | ternary(cluster_api_nonkind_k8s.kpt.packages, []) }}"
+
+- name: Deploy base packages applicable only on nonkind_k8s clusters
+  ansible.builtin.include_role:
+    name: kpt
+  loop: "{{ cluster_api_nonkind_k8s_pkgs }}"
+  vars:
+    repo_uri: "{{ item.repo_uri }}"
+    pkg: "{{ item.pkg }}"
+    version: "{{ item.version }}"
+    context: "{{ k8s.context }}"
+    kpt_async: "{{ item.async }}"
+    kpt_poll: "{{ item.poll }}"
+
+- name: Wait for packages to be applied on nonkind_k8s clusters
+  ansible.builtin.async_status:
+    jid: "{{ item.ansible_job_id }}"
+  register: job_result
+  with_items: "{{ all_kpt_apply }}"
+  when: all_kpt_apply is defined
+  until: job_result.finished
+  retries: 100
+  delay: 15
+
+- name: Create list of namespaces on nonkind_k8s clusters
+  ansible.builtin.set_fact:
+    cluster_api_nonkind_k8s_namespaces: "{{ cluster_api_nonkind_k8s.enabled | ternary(cluster_api_nonkind_k8s.k8s.namespaces, []) }}"
+
+- name: Wait for deployments on nonkind_k8s clusters
+  ansible.builtin.include_tasks: wait-deployments.yml
+  loop: "{{ cluster_api_nonkind_k8s_namespaces }}"
+  loop_control:
+    loop_var: namespace
+  vars:
+    context: "{{ k8s.context }}"

--- a/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/tasks/main.yml
@@ -34,6 +34,28 @@
   tags:
     - always
 
+- name: Debug k8s.context value and its type
+  tags:
+    - always
+  ansible.builtin.debug:
+    msg:
+      - "Value of k8s.context: '{{ k8s.context | default('VARIABLE UNDEFINED') }}'"
+      - "Type of k8s.context: {{ k8s.context | type_debug }}"
+      - "Result of condition 'k8s.context is defined': {{ k8s.context is defined }}"
+      - "Result of condition 'k8s.context != 'kind-kind'': {{ k8s.context | default('__dummy__') != 'kind-kind' }}"
+      - "Overall 'when' condition result (if variable defined): {{ (k8s.context is defined and k8s.context != 'kind-kind') | default('N/A (var undefined)') }}"
+
+- name: Apply kpt packages that are supported only on nonkind_k8s clusters
+  ansible.builtin.include_tasks:
+    file: apply-pkgs-nonkind-k8s.yml
+    apply:
+      tags:
+        - nonkind_k8s
+  tags:
+    - nonkind_k8s
+  when: k8s.context != 'kind-kind'
+
+
 - name: Create docker hub secret
   tags:
     - nonkind_k8s


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

kind feature

> /kind flake

**What this PR does / why we need it**:
This PR adds support for installing the CAPI metal3 components in order to be able to create baremetal clusters.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Adds support for the CAPI metal3 provider components.
The successful run of tests in this PR depends on the PR at https://github.com/nephio-project/catalog/pull/104 being merged.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```
