### PR TITLE
 Upgrade Go base image to 1.23.8 to support Porch version bump

### DIFF
--- a/images/gotests/Dockerfile
+++ b/images/gotests/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /go/src/lichen
 RUN go build -o /tmp/lichen
 
 
-FROM golang:1.23.5-bullseye
+FROM golang:1.23.8-bullseye
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \


### PR DESCRIPTION
**Description:**

This PR upgrades the Go base image used by `gotests` from version `1.23.5` to `1.23.8`. The change ensures compatibility with the Porch project, which now requires Go version `>=1.23.8` following its recent update.

**Details:**

* Updated Go base image: `golang:1.23.5` → `golang:1.23.8`
* Patch-level upgrade only; no breaking changes expected
* Aligns the `gotests` tooling with Porch’s updated requirements

**Reference:**

* Related Porch update: [[nephio-project/porch#236](https://github.com/nephio-project/porch/issues/236)](https://github.com/nephio-project/porch/issues/236)

