### PR TITLE
Fix porch commit msg assertions flux

### DIFF
--- a/e2e/tests/flux/001.sh
+++ b/e2e/tests/flux/001.sh
@@ -51,7 +51,7 @@ k8s_wait_exists "packagerev" "$regional_pkg_rev"
 # Draft creation
 kubectl wait --for jsonpath='{.spec.lifecycle}'=Draft packagerevisions "$regional_pkg_rev" --timeout="600s"
 assert_branch_exists "drafts/regional/v1"
-assert_commit_msg_in_branch "Intermediate commit" "drafts/regional/v1"
+assert_commit_msg_in_branch "Rendering package" "drafts/regional/v1"
 assert_workload_resource_contains "drafts/regional/v1" "clusterName: regional" "Workload cluster has not been transformed properly"
 
 pushd "$(mktemp -d -t "001-pkg-XXX")" >/dev/null
@@ -66,7 +66,7 @@ porchctl rpkg push -n default "$regional_pkg_rev" regional
 porchctl rpkg propose -n default "$regional_pkg_rev"
 kubectl wait --for jsonpath='{.spec.lifecycle}'=Proposed packagerevisions "$regional_pkg_rev" --timeout="600s"
 assert_branch_exists "proposed/regional/v1"
-assert_commit_msg_in_branch "Intermediate commit" "proposed/regional/v1"
+assert_commit_msg_in_branch "Rendering package" "proposed/regional/v1"
 assert_workload_resource_contains "proposed/regional/v1" "nephio.org/site-type: regional" "Workload cluster has not been transformed properly to proposed"
 
 # Approval


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:
Breaking change to porch commit msgs
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
