### PR TITLE
ArgoCD e2e Test

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -417,6 +417,48 @@ presubmits:
                 path: id_rsa
               - key: id_rsa.pub
                 path: id_rsa.pub
+  - name: e2e-argo-ubuntu-jammy
+    annotations:
+    labels:
+    run_if_changed: '^(e2e/tests/argocd/|e2e/lib/|e2e/e2e.sh|e2e/defaults.env)'
+    skip_report: false
+    decorate: true
+    cluster: default
+    spec:
+      containers:
+        - image: "nephio/e2e:latest"
+          command:
+            - "/bin/sh"
+          args:
+            - "-c"
+            - |
+              set -eE; cd "$(git rev-parse --show-toplevel)/e2e/terraform"; trap 'terraform destroy -target module.gcp-ubuntu-jammy -auto-approve' EXIT;
+              terraform init && timeout 120m terraform apply -target module.gcp-ubuntu-jammy -var="e2e_type=argo" -var="fail_fast=true" -auto-approve
+          volumeMounts:
+            - name: satoken
+              mountPath: "/etc/satoken"
+            - name: ssh-key-vol
+              mountPath: "/etc/ssh-key"
+          resources:
+            requests:
+              cpu: 2
+              memory: 2Gi
+      volumes:
+        - name: satoken
+          secret:
+            secretName: satoken
+            items:
+              - key: satoken
+                path: satoken
+        - name: ssh-key-vol
+          secret:
+            secretName: ssh-key-e2e
+            defaultMode: 256
+            items:
+              - key: id_rsa
+                path: id_rsa
+              - key: id_rsa.pub
+                path: id_rsa.pub
   - name: e2e-ocloud-ubuntu-jammy
     annotations:
     labels:

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -417,7 +417,7 @@ presubmits:
                 path: id_rsa
               - key: id_rsa.pub
                 path: id_rsa.pub
-  - name: e2e-argo-ubuntu-jammy
+  - name: e2e-argocd-ubuntu-jammy
     annotations:
     labels:
     run_if_changed: '^(e2e/tests/argocd/|e2e/lib/|e2e/e2e.sh|e2e/defaults.env)'
@@ -433,7 +433,7 @@ presubmits:
             - "-c"
             - |
               set -eE; cd "$(git rev-parse --show-toplevel)/e2e/terraform"; trap 'terraform destroy -target module.gcp-ubuntu-jammy -auto-approve' EXIT;
-              terraform init && timeout 120m terraform apply -target module.gcp-ubuntu-jammy -var="e2e_type=argo" -var="fail_fast=true" -auto-approve
+              terraform init && timeout 120m terraform apply -target module.gcp-ubuntu-jammy -var="e2e_type=argocd" -var="fail_fast=true" -auto-approve
           volumeMounts:
             - name: satoken
               mountPath: "/etc/satoken"

--- a/e2e/tests/argocd/001.sh
+++ b/e2e/tests/argocd/001.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2025 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+## TEST METADATA
+## TEST-NAME: Deploy a ArgoCD specific workload cluster
+##
+
+set -o pipefail
+set -o errexit
+set -o nounset
+[[ ${DEBUG:-false} != "true" ]] || set -o xtrace
+
+# shellcheck source=e2e/defaults.env
+source "$E2EDIR/defaults.env"
+
+# shellcheck source=e2e/lib/k8s.sh
+source "${LIBDIR}/k8s.sh"
+
+# shellcheck source=e2e/lib/capi.sh
+source "${LIBDIR}/capi.sh"
+
+# shellcheck source=e2e/lib/porch.sh
+source "${LIBDIR}/porch.sh"
+
+# shellcheck source=e2e/lib/_assertions.sh
+source "${LIBDIR}/_assertions.sh"
+
+# shellcheck source=e2e/lib/_utils.sh
+source "${LIBDIR}/_utils.sh"
+
+function _curl_workload_cluster_content {
+    curl -s "http://$(kubectl get services -n gitea gitea -o jsonpath='{.status.loadBalancer.ingress[0].ip}'):3000/nephio/mgmt/raw/branch/$1/regional/workload-cluster.yaml"
+}
+
+# Assertions
+
+function assert_workload_resource_contains {
+    assert_contains "$(_curl_workload_cluster_content "$1")" "$2" "$3"
+}
+
+# Patch the ArgoCD Repo Server with the CMPs
+curl -s https://raw.githubusercontent.com/nephio-project/nephio/refs/heads/main/gitops-tools/kpt-argocd-cmp/patch.sh > /tmp/patch.sh && /bin/bash /tmp/patch.sh 
+
+regional_pkg_rev=$(porchctl rpkg clone -n default "https://github.com/nephio-project/catalog.git/infra/capi/nephio-workload-cluster-argo@$BRANCH" --repository mgmt regional | cut -f 1 -d ' ')
+k8s_wait_exists "packagerev" "$regional_pkg_rev"
+
+# Draft creation
+kubectl wait --for jsonpath='{.spec.lifecycle}'=Draft packagerevisions "$regional_pkg_rev" --timeout="600s"
+assert_branch_exists "drafts/regional/v1"
+assert_commit_msg_in_branch "Rendering package" "drafts/regional/v1"
+assert_workload_resource_contains "drafts/regional/v1" "clusterName: regional" "Workload cluster has not been transformed properly"
+
+pushd "$(mktemp -d -t "001-pkg-XXX")" >/dev/null
+trap popd EXIT
+porchctl rpkg pull -n default "$regional_pkg_rev" regional
+kpt fn eval --image "gcr.io/kpt-fn/set-labels:v0.2.0" regional -- "nephio.org/site-type=regional" "nephio.org/region=us-west1"
+assert_contains "$(cat regional/workload-cluster.yaml)" "nephio.org/region: us-west1" "Workload cluster doesn't have region label"
+
+porchctl rpkg push -n default "$regional_pkg_rev" regional
+
+# Proposal
+porchctl rpkg propose -n default "$regional_pkg_rev"
+kubectl wait --for jsonpath='{.spec.lifecycle}'=Proposed packagerevisions "$regional_pkg_rev" --timeout="600s"
+assert_branch_exists "proposed/regional/v1"
+assert_commit_msg_in_branch "Rendering package" "proposed/regional/v1"
+assert_workload_resource_contains "proposed/regional/v1" "nephio.org/site-type: regional" "Workload cluster has not been transformed properly to proposed"
+
+# Approval
+info "approving package $regional_pkg_rev"
+porchctl rpkg approve -n default "$regional_pkg_rev"
+info "approved package $regional_pkg_rev"
+kubectl wait --for jsonpath='{.spec.lifecycle}'=Published packagerevisions "$regional_pkg_rev" --timeout="600s"
+info "published package $regional_pkg_rev"
+
+assert_workload_resource_contains "main" "nephio.org/site-type: regional" "Workload cluster has not been successfully merged into main branch"
+
+k8s_wait_exists "workloadcluster" "regional"
+capi_cluster_ready "regional" false
+
+k8s_wait_exists "apps" "regional" "" "argocd"

--- a/e2e/tests/argocd/002-free5gc-cp.yaml
+++ b/e2e/tests/argocd/002-free5gc-cp.yaml
@@ -1,0 +1,23 @@
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2025 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: free5gc-control-plane
+spec:
+  upstream:
+    repo: catalog-workloads-free5gc
+    package: free5gc-cp
+    workspaceName: main
+  downstream:
+    repo: regional
+    package: free5gc-cp
+  annotations:
+    approval.nephio.org/policy: initial

--- a/e2e/tests/argocd/002.sh
+++ b/e2e/tests/argocd/002.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#!/usr/bin/env bash
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2025 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+## TEST METADATA
+## TEST-NAME: Deploy free5gc-cp to regional workload cluster
+##
+
+set -o pipefail
+set -o errexit
+set -o nounset
+[[ ${DEBUG:-false} != "true" ]] || set -o xtrace
+
+# shellcheck source=e2e/defaults.env
+source "$E2EDIR/defaults.env"
+
+# shellcheck source=e2e/lib/k8s.sh
+source "${LIBDIR}/k8s.sh"
+
+# shellcheck source=e2e/lib/kpt.sh
+source "${LIBDIR}/kpt.sh"
+
+# shellcheck source=e2e/lib/porch.sh
+source "${LIBDIR}/porch.sh"
+
+k8s_apply "$TESTDIR/002-free5gc-cp.yaml"
+
+kubeconfig="$HOME/.kube/config"
+k8s_wait_exists "packagevariant" "free5gc-control-plane"
+porch_wait_published_packagerev "free5gc-cp" "regional" "$PACKAGE_WORKSPACE_NAME"
+kpt_wait_pkg "regional" "free5gc-cp"
+k8s_wait_ready_replicas "statefulset" "mongodb" "$(k8s_get_capi_kubeconfig "regional")" "free5gc-cp"

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -2220,6 +2220,30 @@ periodics:
         - *satoken_volume
         - *sshkey_volume
 
+  - name: e2e-daily-ubuntu-jammy-argo
+    annotations:
+    labels:
+    cron: *cron_daily
+    skip_report: false
+    decorate: true
+    cluster: default
+    extra_refs: *nephio_test_infra_ref
+    spec:
+      containers:
+        - image: "nephio/e2e:latest"
+          command: *command_sh_c
+          args:
+            - |
+              set -eE; cd "$GOPATH/src/nephio_repo/test-infra/e2e/terraform"; trap 'terraform destroy -target module.latest-ubuntu-packer-image -auto-approve' EXIT;
+              terraform init && timeout 120m terraform apply -target module.latest-ubuntu-packer-image -var="e2e_type=argo" -auto-approve
+          volumeMounts:
+            - *satoken_mount
+            - *sshkey_mount
+          resources: *default_resources
+      volumes:
+        - *satoken_volume
+        - *sshkey_volume
+
   # Weekly jobs
   - name: e2e-weekly-ubuntu-jammy-kubeadm
     annotations:

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -2220,7 +2220,7 @@ periodics:
         - *satoken_volume
         - *sshkey_volume
 
-  - name: e2e-daily-ubuntu-jammy-argo
+  - name: e2e-daily-ubuntu-jammy-argocd
     annotations:
     labels:
     cron: *cron_daily
@@ -2235,7 +2235,7 @@ periodics:
           args:
             - |
               set -eE; cd "$GOPATH/src/nephio_repo/test-infra/e2e/terraform"; trap 'terraform destroy -target module.latest-ubuntu-packer-image -auto-approve' EXIT;
-              terraform init && timeout 120m terraform apply -target module.latest-ubuntu-packer-image -var="e2e_type=argo" -auto-approve
+              terraform init && timeout 120m terraform apply -target module.latest-ubuntu-packer-image -var="e2e_type=argocd" -auto-approve
           volumeMounts:
             - *satoken_mount
             - *sshkey_mount


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds a ArgoCD Workload Cluster E2E Test
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Question: 
- Does having the cluster here named "regional" conflict with the Flux test also using the name "regional"?

This test and prow job situation is modeled after the Flux test, so input as to if something should change would be appreciated. This was tested on my lab VM and passed, but obviously the full prow/daily test run was not tested

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
