### PR TITLE
Upgrade gtp5g kernel mod to 0.9.15

### DIFF
--- a/e2e/provision/playbooks/roles/bootstrap/defaults/main.yml
+++ b/e2e/provision/playbooks/roles/bootstrap/defaults/main.yml
@@ -19,7 +19,7 @@ host_reqs:
 container_engine: docker
 
 gtp5g_dest: /opt/gtp5g
-gtp5g_version: v0.9.14
+gtp5g_version: v0.9.15
 gtp5g_tarball_url: "https://github.com/free5gc/gtp5g/archive/refs/tags/{{ gtp5g_version }}.tar.gz"
 
 k8s:

--- a/e2e/provision/tox.ini
+++ b/e2e/provision/tox.ini
@@ -10,27 +10,41 @@ commands =
 
 [testenv:lint]
 deps =
-   {env:BASHATE_INSTALL_PATH:bashate}
-   ansible
-   ansible-lint
-   yamllint
-   black
-   isort
-   flake8
-   vulture
-allowlist_externals = bash
-commands = bash -c "find {toxinidir} \
-   -not -path {toxinidir}/.tox/\* \
-   -not -path {toxinidir}/roles/\* \
-# E006 check for lines longer than 79 columns
-   -name \*.sh | xargs bashate -v -iE006"
-   bash -c "yamllint -c .yaml-lint.yml {toxinidir}"
-   bash -c "black --check {toxinidir}"
-   bash -c "ansible-lint -v"
-   bash -c "isort --check {toxinidir}"
-   bash -c "find {toxinidir} \
-   -not -path {toxinidir}/.tox/\* \
-   -name \*.py | xargs flake8 --ignore=E501"
+    {env:BASHATE_INSTALL_PATH:bashate}
+    -rtest-requirements.txt
+    isort
+    flake8
+
+allowlist_externals =
+    bash
+    find
+    xargs
+
+commands_pre =
+    # Install required Ansible collections to satisfy ansible-lint
+    ansible-galaxy collection install kubernetes.core ansible.posix community.general
+
+commands =
+    # Run bashate on all shell scripts (ignore E006: line length > 79 chars)
+    bash -c "find {toxinidir} \
+        -not -path {toxinidir}/.tox/\* \
+        -not -path {toxinidir}/roles/\* \
+        -name '*.sh' | xargs bashate -v -iE006"
+
+    # Run yamllint with project config
+    bash -c "yamllint -c .yaml-lint.yml {toxinidir}"
+
+    # Enforce Python formatting
+    bash -c "black --check {toxinidir}"
+    bash -c "isort --check {toxinidir}"
+
+    # Run ansible-lint with verbose output
+    bash -c "ansible-lint -v {toxinidir}"
+
+    # Run flake8 (ignoring E501: line length)
+    bash -c "find {toxinidir} \
+        -not -path {toxinidir}/.tox/\* \
+        -name '*.py' | xargs flake8 --ignore=E501"
 
 [testenv:{kpt,bootstrap,install,upgrade}]
 deps = -r{toxinidir}/test-requirements.txt

--- a/e2e/tests/free5gc/008.sh
+++ b/e2e/tests/free5gc/008.sh
@@ -34,6 +34,7 @@ kubeconfig="$HOME/.kube/config"
 # Set the new value for maxUplinkThroughput as a parameter
 new_capacity_value=${1:-20G}
 
+
 #Get the cluster kubeconfig
 info "Getting kubeconfig for edge01"
 cluster_kubeconfig=$(k8s_get_capi_kubeconfig "edge01")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:
Bump gtp5g kernel module to fix failing Free5GC UPF deployments
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
